### PR TITLE
Fix the atomiadns_zoneimport script

### DIFF
--- a/zonefileimporter/atomiadns_zoneimport
+++ b/zonefileimporter/atomiadns_zoneimport
@@ -49,11 +49,6 @@ if ($verbose) {
 	eval 'use SOAP::Lite;';
 }
 
-if (defined($soap_username)) {
-	die "if you specify soap_username, you have to specify soap_password as well" unless defined($soap_password);
-	eval "sub SOAP::Transport::HTTP::Client::get_basic_credentials { return '$soap_username' => '$soap_password' }";
-}
-
 my $soap = SOAP::Lite
 	->  uri('urn:Atomia::DNS::Server')
 	->  proxy($soap_uri)
@@ -61,6 +56,11 @@ my $soap = SOAP::Lite
 			my($soap, $res) = @_;
 			die "got fault of type " . (ref $res ? $res->faultcode  : "transport") . ": " . (ref $res ? $res->faultstring : $soap->transport->status) . "\n";
 		});
+
+if (defined($soap_username)) {
+	$soap->transport->http_request->header('X-Auth-Username' => $soap_username);
+	$soap->transport->http_request->header('X-Auth-Password' => $soap_password);
+}
 
 my $origins = [];
 my $binary_zones = [];


### PR DESCRIPTION
Hi!
The commit message says it all (hopefully):

The script failed with the following error (while the atomiadnsclient did work):

got fault of type soap:AuthError.NotAuthenticated: unauthorized access at /usr/share/perl5/Atomia/DNS/ServerHandler.pm line 1071.

This fix is taken from the atomiadnsclient program

Cheers,

Pieter Lexis
