### PR TITLE
Several fixes for Ubuntu 16.04

### DIFF
--- a/dyndns/Makefile.PL
+++ b/dyndns/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadyndns',
-   'VERSION' => '1.1.43',
+   'VERSION' => '1.1.44',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadyndns' ]
 );

--- a/dyndns/SPECS/atomiadns-dyndns.spec
+++ b/dyndns/SPECS/atomiadns-dyndns.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS DDNS server
 Name: atomiadns-dyndns
-Version: 1.1.43
+Version: 1.1.44
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -80,6 +80,8 @@ fi
 exit 0
 
 %changelog
+* Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
+- Remove apache2-mpm-prefork dependency on Ubuntu 16.04
 * Mon Oct 24 2016 Oscar Linderholm <oscar@atomia.com> - 1.1.43-1
 - Correctly trim white spaces from arguments in atomiadnsclient
 * Fri Feb 19 2016 Jimmy Bergman <jimmy@atomia.com> - 1.1.42-1

--- a/dyndns/debian/changelog
+++ b/dyndns/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.44) hardy; urgency=low
+
+  * Remove apache2-mpm-prefork dependency on Ubuntu 16.04
+
+ -- Stefan Mortensen <stefan@atomia.com>  Fri, 23 Dec 2016 10:34:17 +0100
+
 atomiadns-dyndns (1.1.43) hardy; urgency=low
 
   * Correctly trim white spaces from arguments in atomiadnsclient

--- a/powerdns_sync/Makefile.PL
+++ b/powerdns_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::PowerDNSSyncer',
-   'VERSION' => '1.1.43',
+   'VERSION' => '1.1.44',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiapowerdnssync' ]
 );

--- a/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
+++ b/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS PowerDNS Sync application
 Name: atomiadns-powerdnssync
-Version: 1.1.43
+Version: 1.1.44
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -84,6 +84,8 @@ fi
 exit 0
 
 %changelog
+* Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
+- Remove apache2-mpm-prefork dependency on Ubuntu 16.04
 * Mon Oct 24 2016 Oscar Linderholm <oscar@atomia.com> - 1.1.43-1
 - Correctly trim white spaces from arguments in atomiadnsclient
 * Fri Feb 19 2016 Jimmy Bergman <jimmy@atomia.com> - 1.1.42-1

--- a/powerdns_sync/debian/atomiadns-powerdnssync.atomiadns-powerdnssync.service
+++ b/powerdns_sync/debian/atomiadns-powerdnssync.atomiadns-powerdnssync.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Atomia DNS PowerDNS sync agent
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/atomiapowerdnssync updated 2>&1 | logger -t atomiapowerdnssync_updated
+
+[Install]
+WantedBy=multi-user.target
+

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-powerdnssync (1.1.44) hardy; urgency=low
+
+  * Remove apache2-mpm-prefork dependency on Ubuntu 16.04
+
+ -- Stefan Mortensen <stefan@atomia.com>  Fri, 23 Dec 2016 10:34:17 +0100
+
 atomiadns-powerdnssync (1.1.43) hardy; urgency=low
 
   * Correctly trim white spaces from arguments in atomiadnsclient

--- a/powerdns_sync/debian/control
+++ b/powerdns_sync/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-powerdnssync
 Architecture: all
-Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libmoose-perl, libnet-dns-zonefile-fast-perl, libnet-dns-perl, libmime-base32-perl, libproc-daemon-perl, libdigest-sha-perl
+Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libmoose-perl, libnet-dns-zonefile-fast-perl, libnet-dns-perl, libmime-base32-perl, libproc-daemon-perl, libdigest-sha-perl, ${dist:Depends}
 Recommends: libshell-perl
 Description: Atomia DNS PowerDNS Sync application
 

--- a/powerdns_sync/debian/rules
+++ b/powerdns_sync/debian/rules
@@ -17,8 +17,10 @@ endif
 
 ifeq ($(shell lsb_release -r |  cut -f2 ),16.04)
         INITNAME = --name=atomiadns-powerdnssync
+	SUBSTVARS = -Vdist:Depends="libdbi-perl, libdbd-mysql-perl"
 else
 	INITNAME = ""
+	SUBSTVARS = -Vdist:Depends=""
 endif
 
 SYNCER_DIR=$(CURDIR)/debian/atomiadns-powerdnssync

--- a/powerdns_sync/debian/rules
+++ b/powerdns_sync/debian/rules
@@ -15,6 +15,12 @@ ifndef PERL
 PERL = /usr/bin/perl
 endif
 
+ifeq ($(shell lsb_release -r |  cut -f2 ),16.04)
+        INITNAME = --name=atomiadns-powerdnssync
+else
+	INITNAME = ""
+endif
+
 SYNCER_DIR=$(CURDIR)/debian/atomiadns-powerdnssync
 DB_DIR=$(CURDIR)/debian/atomiadns-powerdns-database
 
@@ -77,7 +83,7 @@ binary-indep: build install
 	dh_installcron
 #	dh_installmenu
 #	dh_installexamples
-	dh_installinit
+	dh_installinit $(INITNAME)
 	dh_installdocs 
 	dh_installchangelogs 
 	dh_perl

--- a/server/Makefile.PL
+++ b/server/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Server',
-   'VERSION' => '1.1.43',
+   'VERSION' => '1.1.44',
    'AUTHOR' => 'Jimmy Bergman <jimmy@pingdom.com>',
    'DIR' => [],
    'EXE_FILES' => [ 'bin/generate_private_key' ]

--- a/server/SPECS/atomiadns-api.spec
+++ b/server/SPECS/atomiadns-api.spec
@@ -5,7 +5,7 @@
 
 Summary: SOAP-server for Atomia DNS
 Name: atomiadns-api
-Version: 1.1.43
+Version: 1.1.44
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -84,6 +84,8 @@ fi
 exit 0
 
 %changelog
+* Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
+- Remove apache2-mpm-prefork dependency on Ubuntu 16.04
 * Mon Oct 24 2016 Oscar Linderholm <oscar@atomia.com> - 1.1.43-1
 - Correctly trim white spaces from arguments in atomiadnsclient
 * Fri Feb 19 2016 Jimmy Bergman <jimmy@atomia.com> - 1.1.42-1

--- a/server/SPECS/atomiadns-client.spec
+++ b/server/SPECS/atomiadns-client.spec
@@ -5,7 +5,7 @@
 
 Summary: Command line client for Atomia DNS
 Name: atomiadns-client
-Version: 1.1.43
+Version: 1.1.44
 Release: 1%{?dist}
 License: Commercial
 Group: Applications/Internet
@@ -53,6 +53,8 @@ cd ..
 %doc %{_mandir}/man1/dnssec_zsk_rollover.1.gz
 
 %changelog
+* Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
+- Remove apache2-mpm-prefork dependency on Ubuntu 16.04
 * Mon Oct 24 2016 Oscar Linderholm <oscar@atomia.com> - 1.1.43-1
 - Correctly trim white spaces from arguments in atomiadnsclient
 * Fri Feb 19 2016 Jimmy Bergman <jimmy@atomia.com> - 1.1.42-1

--- a/server/SPECS/atomiadns-database.spec
+++ b/server/SPECS/atomiadns-database.spec
@@ -5,7 +5,7 @@
 
 Summary: Database schema for Atomia DNS
 Name: atomiadns-database
-Version: 1.1.43
+Version: 1.1.44
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -52,6 +52,8 @@ The Atomia DNS database schema.
 sh /usr/share/atomiadns/atomiadns-database.postinst.sh
 
 %changelog
+* Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
+- Remove apache2-mpm-prefork dependency on Ubuntu 16.04
 * Mon Oct 24 2016 Oscar Linderholm <oscar@atomia.com> - 1.1.43-1
 - Correctly trim white spaces from arguments in atomiadnsclient
 * Fri Feb 19 2016 Jimmy Bergman <jimmy@atomia.com> - 1.1.42-1

--- a/server/SPECS/atomiadns-masterserver.spec
+++ b/server/SPECS/atomiadns-masterserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Complete master SOAP server for Atomia DNS
 Name: atomiadns-masterserver
-Version: 1.1.43
+Version: 1.1.44
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -18,7 +18,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildArch: noarch
 
-Requires: atomiadns-api >= 1.1.43 atomiadns-database >= 1.1.43
+Requires: atomiadns-api >= 1.1.44 atomiadns-database >= 1.1.44
 
 %description
 Complete master SOAP server for Atomia DNS
@@ -37,6 +37,8 @@ Complete master SOAP server for Atomia DNS
 %files
 
 %changelog
+* Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
+- Remove apache2-mpm-prefork dependency on Ubuntu 16.04
 * Mon Oct 24 2016 Oscar Linderholm <oscar@atomia.com> - 1.1.43-1
 - Correctly trim white spaces from arguments in atomiadnsclient
 * Fri Feb 19 2016 Jimmy Bergman <jimmy@atomia.com> - 1.1.42-1

--- a/server/client/Makefile.PL
+++ b/server/client/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadnsclient',
-   'VERSION' => '1.1.43',
+   'VERSION' => '1.1.44',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadnsclient', 'dnssec_zsk_rollover' ]
 );

--- a/server/debian/atomiadns-api.postinst
+++ b/server/debian/atomiadns-api.postinst
@@ -6,7 +6,7 @@ if [ ! -e /etc/apache2/mods-enabled/rewrite.load ]; then
 	ln -s ../mods-available/rewrite.load
 fi
 
-if [ -f /usr/bin/lsb_release ] && [ `/usr/bin/lsb_release -rs` = "14.04" ]; then
+if [ -f /usr/bin/lsb_release ] && [ `/usr/bin/lsb_release -rs` = "14.04" ] || [ `/usr/bin/lsb_release -rs` = "16.04" ]; then
 	if [ -f /etc/apache2/conf.d/atomiadns ]; then
 		mv /etc/apache2/conf.d/atomiadns /etc/apache2/conf-available/atomiadns.conf
 		cd /etc/apache2/conf-enabled

--- a/server/debian/changelog
+++ b/server/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-masterserver (1.1.44) hardy; urgency=low
+
+  * Remove apache2-mpm-prefork dependency on Ubuntu 16.04
+
+ -- Stefan Mortensen <stefan@atomia.com>  Fri, 23 Dec 2016 10:34:17 +0100
+
 atomiadns-masterserver (1.1.43) hardy; urgency=low
 
   * Correctly trim white spaces from arguments in atomiadnsclient

--- a/server/debian/control
+++ b/server/debian/control
@@ -8,12 +8,12 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-masterserver
 Architecture: all
-Depends: atomiadns-api (>= 1.1.43), atomiadns-database (>= 1.1.43)
+Depends: atomiadns-api (>= 1.1.44), atomiadns-database (>= 1.1.44)
 Description: Complete master SOAP server for Atomia DNS
 
 Package: atomiadns-api
 Architecture: all
-Depends: perl-modules, perl-base, libconfig-general-perl, libdbi-perl, libsoap-lite-perl (>= 0.710.08-2), libdbd-pg-perl (>= 2.11.7-1), libmoose-perl, apache2, apache2-mpm-prefork, libapache2-mod-perl2, bind9utils, libjson-perl, libauthen-passphrase-perl, libdigest-sha-perl, libnet-dns-perl, libnet-dns-sec-perl
+Depends: perl-modules, perl-base, libconfig-general-perl, libdbi-perl, libsoap-lite-perl (>= 0.710.08-2), libdbd-pg-perl (>= 2.11.7-1), libmoose-perl, apache2, libapache2-mod-perl2, bind9utils, libjson-perl, libauthen-passphrase-perl, libdigest-sha-perl, libnet-dns-perl, libnet-dns-sec-perl, ${dist:Depends}
 Description: SOAP-server for Atomia DNS
 
 Package: atomiadns-database

--- a/server/debian/rules
+++ b/server/debian/rules
@@ -19,6 +19,11 @@ ifndef PERL
 PERL = /usr/bin/perl
 endif
 
+ifeq ($(shell lsb_release -r |  cut -f2 ),16.04)
+        SUBSTVARS = -Vdist:Depends=""
+else
+        SUBSTVARS = -Vdist:Depends="apache2-mpm-prefork"
+endif
 
 build: build-stamp
 build-stamp:
@@ -96,7 +101,7 @@ binary-indep: build install
 	dh_compress
 	dh_fixperms
 	dh_installdeb
-	dh_gencontrol
+	dh_gencontrol -- $(SUBSTVARS)
 	dh_md5sums
 	dh_builddeb
 

--- a/syncer/Makefile.PL
+++ b/syncer/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Syncer',
-   'VERSION' => '1.1.43',
+   'VERSION' => '1.1.44',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadnssync' ]
 );

--- a/syncer/SPECS/atomiadns-nameserver.spec
+++ b/syncer/SPECS/atomiadns-nameserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS Sync application
 Name: atomiadns-nameserver
-Version: 1.1.43
+Version: 1.1.44
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -107,6 +107,8 @@ fi
 exit 0
 
 %changelog
+* Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
+- Remove apache2-mpm-prefork dependency on Ubuntu 16.04
 * Mon Oct 24 2016 Oscar Linderholm <oscar@atomia.com> - 1.1.43-1
 - Correctly trim white spaces from arguments in atomiadnsclient
 * Fri Feb 19 2016 Jimmy Bergman <jimmy@atomia.com> - 1.1.42-1

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-nameserver (1.1.44) hardy; urgency=low
+
+  * Remove apache2-mpm-prefork dependency on Ubuntu 16.04
+
+ -- Stefan Mortensen <stefan@atomia.com>  Fri, 23 Dec 2016 10:34:17 +0100
+
 atomiadns-nameserver (1.1.43) hardy; urgency=low
 
   * Correctly trim white spaces from arguments in atomiadnsclient

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-webapp (1.1.44) hardy; urgency=low
+
+  * Remove apache2-mpm-prefork dependency on Ubuntu 16.04
+
+ -- Stefan Mortensen <stefan@atomia.com>  Fri, 23 Dec 2016 10:34:17 +0100
+
 atomiadns-webapp (1.1.43) hardy; urgency=low
 
   * Correctly trim white spaces from arguments in atomiadnsclient

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atomiadns-controlpanel",
-	"version": "1.1.43",
+	"version": "1.1.44",
 	"private": true,
 	"dependencies": {
 		"express":		"= 3.0.6",

--- a/zonefileimporter/Makefile.PL
+++ b/zonefileimporter/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadns_zoneimport',
-   'VERSION' => '1.1.43',
+   'VERSION' => '1.1.44',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadns_zoneimport' ]
 );

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-zoneimport (1.1.44) hardy; urgency=low
+
+  * Remove apache2-mpm-prefork dependency on Ubuntu 16.04
+
+ -- Stefan Mortensen <stefan@atomia.com>  Fri, 23 Dec 2016 10:34:17 +0100
+
 atomiadns-zoneimport (1.1.43) hardy; urgency=low
 
   * Correctly trim white spaces from arguments in atomiadnsclient


### PR DESCRIPTION
The apache2-mpm-prefork package is included with Apache on Ubuntu 16.04 so we no longer need this dependency.

Apache config update to use the "new style"

Systemd has replaced upstart so added a systemd script for atomiadns-powerdnssync

2 additional dependencies (libdbi-perl, libdbd-mysql-perl) needed for atomiadns-powerdnssync