### PR TITLE
Add Support for CAA records

### DIFF
--- a/dyndns/debian/changelog
+++ b/dyndns/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-masterserver (1.1.45) hardy; urgency=low
+atomiadns-dyndns (1.1.45) hardy; urgency=low
 
   * Add support for CAA
 

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-masterserver (1.1.45) hardy; urgency=low
+atomiadns-powerdnssync (1.1.45) hardy; urgency=low
 
   * Add support for CAA
 

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-masterserver (1.1.45) hardy; urgency=low
+atomiadns-nameserver (1.1.45) hardy; urgency=low
 
   * Add support for CAA
 

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-masterserver (1.1.45) hardy; urgency=low
+atomiadns-webapp (1.1.45) hardy; urgency=low
 
   * Add support for CAA
 

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-masterserver (1.1.45) hardy; urgency=low
+atomiadns-zoneimport (1.1.45) hardy; urgency=low
 
   * Add support for CAA
 


### PR DESCRIPTION
Fix for commit:
https://github.com/atomia/atomiadns/commit/e0a96968164422211376501dd82b6dba77621961
Fixed changelog

Resolves PROD-233

ChangeLog
* [ADD] Support for CAA records