### PR TITLE
Fix RHEL changelog in SPEC files

### DIFF
--- a/dyndns/SPECS/atomiadns-dyndns.spec
+++ b/dyndns/SPECS/atomiadns-dyndns.spec
@@ -80,7 +80,7 @@ fi
 exit 0
 
 %changelog
-* Thu, 21 Sep 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
+* Thu Sep 20 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
 - Add support for CAA
 * Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
 - Remove apache2-mpm-prefork dependency on Ubuntu 16.04

--- a/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
+++ b/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
@@ -84,7 +84,7 @@ fi
 exit 0
 
 %changelog
-* Thu, 21 Sep 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
+* Thu Sep 21 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
 - Add support for CAA
 * Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
 - Remove apache2-mpm-prefork dependency on Ubuntu 16.04

--- a/server/SPECS/atomiadns-api.spec
+++ b/server/SPECS/atomiadns-api.spec
@@ -84,7 +84,7 @@ fi
 exit 0
 
 %changelog
-* Thu, 21 Sep 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
+* Thu Sep 21 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
 - Add support for CAA
 * Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
 - Remove apache2-mpm-prefork dependency on Ubuntu 16.04

--- a/server/SPECS/atomiadns-client.spec
+++ b/server/SPECS/atomiadns-client.spec
@@ -53,7 +53,7 @@ cd ..
 %doc %{_mandir}/man1/dnssec_zsk_rollover.1.gz
 
 %changelog
-* Thu, 21 Sep 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
+* Thu Sep 21 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
 - Add support for CAA
 * Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
 - Remove apache2-mpm-prefork dependency on Ubuntu 16.04

--- a/server/SPECS/atomiadns-database.spec
+++ b/server/SPECS/atomiadns-database.spec
@@ -52,7 +52,7 @@ The Atomia DNS database schema.
 sh /usr/share/atomiadns/atomiadns-database.postinst.sh
 
 %changelog
-* Thu, 21 Sep 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
+* Thu Sep 21 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
 - Add support for CAA
 * Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
 - Remove apache2-mpm-prefork dependency on Ubuntu 16.04

--- a/server/SPECS/atomiadns-masterserver.spec
+++ b/server/SPECS/atomiadns-masterserver.spec
@@ -37,7 +37,7 @@ Complete master SOAP server for Atomia DNS
 %files
 
 %changelog
-* Thu, 21 Sep 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
+* Thu Sep 21 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
 - Add support for CAA
 * Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
 - Remove apache2-mpm-prefork dependency on Ubuntu 16.04

--- a/syncer/SPECS/atomiadns-nameserver.spec
+++ b/syncer/SPECS/atomiadns-nameserver.spec
@@ -107,7 +107,7 @@ fi
 exit 0
 
 %changelog
-* Thu, 21 Sep 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
+* Thu Sep 21 2017 Stefan Stankovic <stefan.stankovic@atomia.com> 1.1.45-1
 - Add support for CAA
 * Fri Dec 23 2016 Stefan Mortensen <stefan@atomia.com> - 1.1.44-1
 - Remove apache2-mpm-prefork dependency on Ubuntu 16.04


### PR DESCRIPTION
Fix invalid date format in the SPEC files %changelog section, introduced
with the last commit (Support for CAA records). This prevented RHEL
packages from building.