### PR TITLE
Require perl-Moose as dependency

### DIFF
--- a/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
+++ b/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
@@ -17,7 +17,7 @@ Vendor: Atomia AB RPM Repository http://rpm.atomia.com/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 Requires(pre): shadow-utils
-Requires: perl-Class-MOP >= 0.92
+Requires: perl-Moose >= 2.0
 
 BuildArch: noarch
 BuildRequires: perl

--- a/server/SPECS/atomiadns-api.spec
+++ b/server/SPECS/atomiadns-api.spec
@@ -16,7 +16,7 @@ Packager: Jimmy Bergman <jimmy@atomia.com>
 Vendor: Atomia AB RPM Repository http://rpm.atomia.com/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
-Requires: httpd mod_perl >= 2.0 perl-Class-MOP >= 0.92
+Requires: httpd mod_perl >= 2.0 perl-Moose >= 2.0
 
 BuildArch: noarch
 BuildRequires: perl

--- a/syncer/SPECS/atomiadns-nameserver.spec
+++ b/syncer/SPECS/atomiadns-nameserver.spec
@@ -17,7 +17,7 @@ Vendor: Atomia AB RPM Repository http://rpm.atomia.com/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 Requires(pre): shadow-utils
-Requires: bind-dlz-bdbhpt-driver perl-Class-MOP >= 0.92
+Requires: bind-dlz-bdbhpt-driver perl-Moose >= 2.0
 
 BuildArch: noarch
 BuildRequires: perl


### PR DESCRIPTION
Require perl-Moose as dependency instead of perl-Class-MOP, since the
latter is not available for RHEL7 standalone and is provided by
perl-Moose.

Amends PROD-528