### PR TITLE
Remove alter table global_domainmetadata

### DIFF
--- a/powerdns_sync/debian/atomiadns-powerdns-database.postinst
+++ b/powerdns_sync/debian/atomiadns-powerdns-database.postinst
@@ -218,7 +218,6 @@ ALTER VIEW powerdns.cryptokeys AS
 
 			if [ "$schema_version" -lt 14 ]; then
 				execute_query "DROP VIEW IF EXISTS domainmetadata"
-				execute_query "ALTER TABLE global_domainmetadata CHARACTER SET 'latin1'"
 				execute_query "CREATE TABLE domainmetadata (
 												id                    INT AUTO_INCREMENT,
 												domain_id             INT NOT NULL,
@@ -260,7 +259,7 @@ ALTER VIEW powerdns.cryptokeys AS
 
 															IF global_cryptokeys_count > 0 THEN
 																	INSERT INTO domainmetadata (domain_id, kind, content)
-																	SELECT 
+																	SELECT
 																	d.id AS domain_id,
 																	IF(d.type IN ('NATIVE', 'MASTER'), new_kind, 'AXFR-MASTER-TSIG') AS kind,
 																	IF(d.type IN ('NATIVE', 'MASTER'),

--- a/powerdns_sync/schema/powerdns.sql
+++ b/powerdns_sync/schema/powerdns.sql
@@ -255,8 +255,6 @@ CREATE INDEX comments_order_idx ON comments (domain_id, modified_at);
 -- Dump completed on 2011-04-15 10:55:35
 
 DROP VIEW IF EXISTS domainmetadata;
-ALTER TABLE global_domainmetadata CHARACTER SET 'latin1';
-
 CREATE TABLE domainmetadata (
   id                    INT AUTO_INCREMENT,
   domain_id             INT NOT NULL,


### PR DESCRIPTION
Removed alter table global_domainmetadata because of it already
has set latin1.

Amends PROD-1799

ChangeLog:
/