### PR TITLE
Remove NET::DNS::ZoneFile::Fast dependency

### DIFF
--- a/powerdns_sync/debian/control
+++ b/powerdns_sync/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-powerdnssync
 Architecture: all
-Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libmoose-perl, libnet-dns-zonefile-fast-perl, libnet-dns-perl, libmime-base32-perl, libproc-daemon-perl, libdigest-sha-perl, ${dist:Depends}
+Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libmoose-perl, libnet-dns-perl, libmime-base32-perl, libproc-daemon-perl, libdigest-sha-perl, ${dist:Depends}
 Recommends: libshell-perl
 Description: Atomia DNS PowerDNS Sync application
 

--- a/powerdns_sync/lib/Atomia/DNS/PowerDNSSyncer.pm
+++ b/powerdns_sync/lib/Atomia/DNS/PowerDNSSyncer.pm
@@ -10,7 +10,7 @@ use Config::General;
 use SOAP::Lite;
 use Data::Dumper;
 use Atomia::DNS::PowerDNSDatabase;
-use Net::DNS::ZoneFile::Fast;
+use Net::DNS::ZoneFile;
 
 has 'config' => (is => 'rw', isa => 'Any', default => undef);
 has 'configfile' => (is => 'ro', isa => 'Any', default => "/etc/atomiadns.conf");
@@ -368,7 +368,8 @@ sub import_zonefile {
 
 	$zone_origin =~ s/\.$//;
 
-	my $parsed_zone = Net::DNS::ZoneFile::Fast::parse(file => $zone_file, origin => $zone_origin);
+    my $zonefile = new Net::DNS::ZoneFile( $zone_file, [$zone_origin] );
+	my $parsed_zone = $zonefile->read;
 
 	my $zone = { name => $zone_origin };
 	my $records = [];

--- a/zonefileimporter/atomiadns_zoneimport
+++ b/zonefileimporter/atomiadns_zoneimport
@@ -7,7 +7,7 @@ use Data::Dumper;
 use Getopt::Long;
 use Pod::Usage;
 use Config::General;
-use Net::DNS::ZoneFile::Fast;
+use Net::DNS::ZoneFile;
 
 my $config_file = "/etc/atomiadns.conf";
 my $soap_uri = undef;
@@ -76,7 +76,8 @@ foreach $_ (@$zones) {
 
 		$zone_origin =~ s/\.$//;
 
-		my $parsed_zone = Net::DNS::ZoneFile::Fast::parse(file => $zone_file, origin => $zone_origin);
+        my $zonefile = new Net::DNS::ZoneFile( $zone_file, [$zone_origin] );
+		my $parsed_zone = $zonefile->read;
 
 		my $zone = "";
 		foreach my $record (@$parsed_zone) {

--- a/zonefileimporter/debian/control
+++ b/zonefileimporter/debian/control
@@ -8,6 +8,6 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-zoneimport
 Architecture: all
-Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libnet-dns-zonefile-fast-perl, libnet-dns-perl
+Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libnet-dns-perl
 Recommends: libshell-perl
 Description: Atomia DNS zone file importer.


### PR DESCRIPTION
Removed NET::DNS::ZoneFile::Fast dependency.
Moved from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile

Resolves PROD-2490.

ChangeLog:

*[FIX]  Removed NET::DNS::ZoneFile::Fast dependency.