### PR TITLE
Remove  NET::DNS::ZoneFile::Fast dependency

### DIFF
--- a/dyndns/Makefile.PL
+++ b/dyndns/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadyndns',
-   'VERSION' => '1.1.48',
+   'VERSION' => '1.1.49',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadyndns' ]
 );

--- a/dyndns/SPECS/atomiadns-dyndns.spec
+++ b/dyndns/SPECS/atomiadns-dyndns.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS DDNS server
 Name: atomiadns-dyndns
-Version: 1.1.48
+Version: 1.1.49
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -82,6 +82,8 @@ fi
 exit 0
 
 %changelog
+* Wed Dec 02 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.49-1
+- Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
 * Wed May 08 2019 Stefan Stankovic <stefan.stankovic@atomia.com> - 1.1.48-1
 - Update PowerDNS DB schema in order to pdns upgrade
 * Wed Jan 23 2019 Andreas Dilworth <andreas.dilworth@binero.se> - 1.1.47-1

--- a/dyndns/debian/changelog
+++ b/dyndns/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.48) hardy; urgency=low
+atomiadns-dyndns (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/dyndns/debian/changelog
+++ b/dyndns/debian/changelog
@@ -1,5 +1,11 @@
 atomiadns-dyndns (1.1.48) hardy; urgency=low
 
+  * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
+  
+ -- Jovana Stamenkovic <jovana.stamenkovic@atomia.com> Wed, 2 Dec 2020 11:44:30 +0100
+   
+atomiadns-dyndns (1.1.48) hardy; urgency=low
+
   * Update PowerDNS DB schema in order to pdns upgrade
 
  -- Stefan Stankovic <stefan.stankovic@atomia.com>  Wed, 8 May 2019 00:44:58 -0700

--- a/powerdns_sync/Makefile.PL
+++ b/powerdns_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::PowerDNSSyncer',
-   'VERSION' => '1.1.48',
+   'VERSION' => '1.1.49',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiapowerdnssync' ]
 );

--- a/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
+++ b/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS PowerDNS Sync application
 Name: atomiadns-powerdnssync
-Version: 1.1.48
+Version: 1.1.49
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -85,6 +85,8 @@ fi
 exit 0
 
 %changelog
+* Wed Dec 02 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.49-1
+- Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
 * Wed May 08 2019 Stefan Stankovic <stefan.stankovic@atomia.com> - 1.1.48-1
 - Update PowerDNS DB schema in order to pdns upgrade
 * Wed Jan 23 2019 Andreas Dilworth <andreas.dilworth@binero.se> - 1.1.47-1

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.48) hardy; urgency=low
+
+  * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
+  
+ -- Jovana Stamenkovic <jovana.stamenkovic@atomia.com> Wed, 2 Dec 2020 11:44:30 +0100
+   
 atomiadns-powerdnssync (1.1.48) hardy; urgency=low
 
   * Update PowerDNS DB schema in order to pdns upgrade

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.49) hardy; urgency=low
+atomiadns-powerdnssync (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.48) hardy; urgency=low
+atomiadns-dyndns (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/server/Makefile.PL
+++ b/server/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Server',
-   'VERSION' => '1.1.48',
+   'VERSION' => '1.1.49',
    'AUTHOR' => 'Jimmy Bergman <jimmy@pingdom.com>',
    'DIR' => [],
    'EXE_FILES' => [ 'bin/generate_private_key' ]

--- a/server/SPECS/atomiadns-api.spec
+++ b/server/SPECS/atomiadns-api.spec
@@ -5,7 +5,7 @@
 
 Summary: SOAP-server for Atomia DNS
 Name: atomiadns-api
-Version: 1.1.48
+Version: 1.1.49
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -85,6 +85,8 @@ fi
 exit 0
 
 %changelog
+* Wed Dec 02 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.49-1
+- Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
 * Wed May 08 2019 Stefan Stankovic <stefan.stankovic@atomia.com> - 1.1.48-1
 - Update PowerDNS DB schema in order to pdns upgrade
 * Wed Jan 23 2019 Andreas Dilworth <andreas.dilworth@binero.se> - 1.1.47-1

--- a/server/SPECS/atomiadns-client.spec
+++ b/server/SPECS/atomiadns-client.spec
@@ -5,7 +5,7 @@
 
 Summary: Command line client for Atomia DNS
 Name: atomiadns-client
-Version: 1.1.48
+Version: 1.1.49
 Release: 1%{?dist}
 License: Commercial
 Group: Applications/Internet
@@ -53,6 +53,8 @@ cd ..
 %doc %{_mandir}/man1/dnssec_zsk_rollover.1.gz
 
 %changelog
+* Wed Dec 02 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.49-1
+- Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
 * Wed May 08 2019 Stefan Stankovic <stefan.stankovic@atomia.com> - 1.1.48-1
 - Update PowerDNS DB schema in order to pdns upgrade
 * Wed Jan 23 2019 Andreas Dilworth <andreas.dilworth@binero.se> - 1.1.47-1

--- a/server/SPECS/atomiadns-database.spec
+++ b/server/SPECS/atomiadns-database.spec
@@ -5,7 +5,7 @@
 
 Summary: Database schema for Atomia DNS
 Name: atomiadns-database
-Version: 1.1.48
+Version: 1.1.49
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -52,6 +52,8 @@ The Atomia DNS database schema.
 sh /usr/share/atomiadns/atomiadns-database.postinst.sh
 
 %changelog
+* Wed Dec 02 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.49-1
+- Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
 * Wed May 08 2019 Stefan Stankovic <stefan.stankovic@atomia.com> - 1.1.48-1
 - Update PowerDNS DB schema in order to pdns upgrade
 * Wed Jan 23 2019 Andreas Dilworth <andreas.dilworth@binero.se> - 1.1.47-1

--- a/server/SPECS/atomiadns-masterserver.spec
+++ b/server/SPECS/atomiadns-masterserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Complete master SOAP server for Atomia DNS
 Name: atomiadns-masterserver
-Version: 1.1.48
+Version: 1.1.49
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -18,7 +18,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildArch: noarch
 
-Requires: atomiadns-api >= 1.1.48 atomiadns-database >= 1.1.48
+Requires: atomiadns-api >= 1.1.49 atomiadns-database >= 1.1.49
 
 %description
 Complete master SOAP server for Atomia DNS
@@ -37,6 +37,8 @@ Complete master SOAP server for Atomia DNS
 %files
 
 %changelog
+* Wed Dec 02 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.49-1
+- Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
 * Wed May 08 2019 Stefan Stankovic <stefan.stankovic@atomia.com> - 1.1.48-1
 - Update PowerDNS DB schema in order to pdns upgrade
 * Wed Jan 23 2019 Andreas Dilworth <andreas.dilworth@binero.se> - 1.1.47-1

--- a/server/client/Makefile.PL
+++ b/server/client/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadnsclient',
-   'VERSION' => '1.1.48',
+   'VERSION' => '1.1.49',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadnsclient', 'dnssec_zsk_rollover' ]
 );

--- a/server/debian/changelog
+++ b/server/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.48) hardy; urgency=low
+
+  * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
+  
+ -- Jovana Stamenkovic <jovana.stamenkovic@atomia.com> Wed, 2 Dec 2020 11:44:30 +0100
+   
 atomiadns-masterserver (1.1.48) hardy; urgency=low
 
   * Update PowerDNS DB schema in order to pdns upgrade

--- a/server/debian/changelog
+++ b/server/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.48) hardy; urgency=low
+atomiadns-dyndns (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/server/debian/changelog
+++ b/server/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.49) hardy; urgency=low
+atomiadns-masterserver (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/server/debian/control
+++ b/server/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-masterserver
 Architecture: all
-Depends: atomiadns-api (>= 1.1.48), atomiadns-database (>= 1.1.48)
+Depends: atomiadns-api (>= 1.1.49), atomiadns-database (>= 1.1.49)
 Description: Complete master SOAP server for Atomia DNS
 
 Package: atomiadns-api

--- a/syncer/Makefile.PL
+++ b/syncer/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Syncer',
-   'VERSION' => '1.1.48',
+   'VERSION' => '1.1.49',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadnssync' ]
 );

--- a/syncer/SPECS/atomiadns-nameserver.spec
+++ b/syncer/SPECS/atomiadns-nameserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS Sync application
 Name: atomiadns-nameserver
-Version: 1.1.48
+Version: 1.1.49
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -108,6 +108,8 @@ fi
 exit 0
 
 %changelog
+* Wed Dec 02 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.49-1
+- Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
 * Wed May 08 2019 Stefan Stankovic <stefan.stankovic@atomia.com> - 1.1.48-1
 - Update PowerDNS DB schema in order to pdns upgrade
 * Wed Jan 23 2019 Andreas Dilworth <andreas.dilworth@binero.se> - 1.1.47-1

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.49) hardy; urgency=low
+atomiadns-nameserver (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.48) hardy; urgency=low
+atomiadns-dyndns (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.48) hardy; urgency=low
+
+  * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
+  
+ -- Jovana Stamenkovic <jovana.stamenkovic@atomia.com> Wed, 2 Dec 2020 11:44:30 +0100
+   
 atomiadns-nameserver (1.1.48) hardy; urgency=low
 
   * Update PowerDNS DB schema in order to pdns upgrade

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.48) hardy; urgency=low
+atomiadns-dyndns (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.48) hardy; urgency=low
+
+  * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
+  
+ -- Jovana Stamenkovic <jovana.stamenkovic@atomia.com> Wed, 2 Dec 2020 11:44:30 +0100
+   
 atomiadns-webapp (1.1.48) hardy; urgency=low
 
   * Update PowerDNS DB schema in order to pdns upgrade

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.49) hardy; urgency=low
+atomiadns-webapp (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/webapp/npm-shrinkwrap.json
+++ b/webapp/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "atomiadns-controlpanel",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "dependencies": {
     "accepts": {
       "version": "1.0.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atomiadns-controlpanel",
-	"version": "1.1.48",
+	"version": "1.1.49",
 	"private": true,
 	"dependencies": {
 		"express":		"= 3.11.0",

--- a/zonefileimporter/Makefile.PL
+++ b/zonefileimporter/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadns_zoneimport',
-   'VERSION' => '1.1.48',
+   'VERSION' => '1.1.49',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadns_zoneimport' ]
 );

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.49) hardy; urgency=low
+atomiadns-zoneimport (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,4 +1,4 @@
-atomiadns-dyndns (1.1.48) hardy; urgency=low
+atomiadns-dyndns (1.1.49) hardy; urgency=low
 
   * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
   

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.48) hardy; urgency=low
+
+  * Move from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile
+  
+ -- Jovana Stamenkovic <jovana.stamenkovic@atomia.com> Wed, 2 Dec 2020 11:44:30 +0100
+   
 atomiadns-zoneimport (1.1.48) hardy; urgency=low
 
   * Update PowerDNS DB schema in order to pdns upgrade


### PR DESCRIPTION
Moved from NET::DNS::ZoneFile::Fast to NET::DNS::ZoneFile.

Amends PROD-2490.