### PR TITLE
Fix AXFR-slave zone bug

### DIFF
--- a/server/schema/assigntsigkey.sql
+++ b/server/schema/assigntsigkey.sql
@@ -15,7 +15,10 @@ BEGIN
 
 	SELECT zone.id INTO domain_id_var FROM zone WHERE name = domain;
 	IF NOT FOUND THEN
-		RAISE EXCEPTION 'domain % not found', domain;
+		SELECT slavezone.id INTO domain_id_var FROM slavezone WHERE name = domain;
+		IF NOT FOUND THEN
+			RAISE EXCEPTION 'domain % not found', domain;
+		END IF;
 	END IF;
 
 	INSERT INTO domainmetadata (nameserver_group_id, domain_id, kind, tsigkey_name) VALUES (nameserver_group_id_var, domain_id_var, kind, tsigkey_name);

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -420,7 +420,7 @@ BEGIN
 	IF NEW.kind = 'TSIG-ALLOW-AXFR' THEN
 		SELECT zone.name INTO domain_name_var FROM zone WHERE zone.id = NEW.domain_id;
 	ELSE
-		SELECT slavezone.name INTO domain_name_var FROM slavezone WHERE slavezone.id = new.domain_id;
+		SELECT slavezone.name INTO domain_name_var FROM slavezone WHERE slavezone.id = NEW.domain_id;
 	END IF;
 
 	INSERT INTO domainmetadata_change (nameserver_id, domain_id)

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -384,7 +384,7 @@ EXECUTE PROCEDURE tsigkey_update();
 CREATE TABLE domainmetadata (
 	id BIGSERIAL PRIMARY KEY NOT NULL,
 	nameserver_group_id INT NOT NULL REFERENCES nameserver,
-	domain_id INT NOT NULL UNIQUE REFERENCES zone,
+	domain_id INT NOT NULL,
 	kind VARCHAR(255) NOT NULL CONSTRAINT kind_format CHECK (kind IN ('TSIG-ALLOW-AXFR','AXFR-MASTER-TSIG')),
     tsigkey_name VARCHAR(255) NOT NULL CONSTRAINT tsig_name_format CHECK (tsigkey_name ~* '^[a-zA-Z0-9_-]*')
 );
@@ -399,18 +399,32 @@ CREATE TABLE domainmetadata_change (
 );
 
 CREATE OR REPLACE FUNCTION domainmetadata_update() RETURNS trigger AS $$
+DECLARE
+	domain_name_var varchar;
 BEGIN
 	IF TG_OP = 'DELETE' THEN
+		IF OLD.kind = 'TSIG-ALLOW-AXFR' THEN
+			SELECT zone.name INTO domain_name_var FROM zone WHERE zone.id = OLD.domain_id;
+		ELSE
+			SELECT slavezone.name INTO domain_name_var FROM slavezone WHERE slavezone.id = OLD.domain_id;
+		END IF;
+
 		INSERT INTO domainmetadata_change (nameserver_id, domain_id)
-		SELECT nameserver.id, OLD.domain_id FROM nameserver WHERE nameserver.nameserver_group_id = OLD.nameserver_group_id;
+		SELECT nameserver.id, OLD.id || ',' || domain_name_var FROM nameserver WHERE nameserver.nameserver_group_id = OLD.nameserver_group_id;
 		RETURN OLD;
 	ELSIF TG_OP = 'UPDATE' THEN
 		INSERT INTO domainmetadata_change (nameserver_id, domain_id)
-		SELECT nameserver.id, OLD.domain_id FROM nameserver WHERE nameserver.nameserver_group_id = OLD.nameserver_group_id;
+		SELECT nameserver.id, OLD.id FROM nameserver WHERE nameserver.nameserver_group_id = OLD.nameserver_group_id;
+	END IF;
+
+	IF NEW.kind = 'TSIG-ALLOW-AXFR' THEN
+		SELECT zone.name INTO domain_name_var FROM zone WHERE zone.id = NEW.domain_id;
+	ELSE
+		SELECT slavezone.name INTO domain_name_var FROM slavezone WHERE slavezone.id = new.domain_id;
 	END IF;
 
 	INSERT INTO domainmetadata_change (nameserver_id, domain_id)
-	SELECT nameserver.id, NEW.domain_id FROM nameserver WHERE nameserver.nameserver_group_id = NEW.nameserver_group_id;
+	SELECT nameserver.id, NEW.id || ',' || domain_name_var FROM nameserver WHERE nameserver.nameserver_group_id = NEW.nameserver_group_id;
 
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;

--- a/server/schema/getdomainmetadata.sql
+++ b/server/schema/getdomainmetadata.sql
@@ -8,12 +8,12 @@ DECLARE
 	r RECORD;
 	domain_id_check INT;
 BEGIN
-        SELECT id INTO domain_id_check FROM domainmetadata WHERE domain_id = CAST(domainid AS INT);
+        SELECT id INTO domain_id_check FROM domainmetadata WHERE id = CAST(domainid AS INT);
         IF NOT FOUND THEN
                 RAISE EXCEPTION 'Domain id % not found', domainid;
         END IF;
 
-	FOR r IN	SELECT domain_id, kind, tsigkey_name FROM domainmetadata WHERE domain_id = CAST(domainid AS INT)
+	FOR r IN	SELECT domain_id, kind, tsigkey_name FROM domainmetadata WHERE id = CAST(domainid AS INT)
 	LOOP
 		record_domain_id := r.domain_id;
 		record_kind := r.kind;

--- a/server/schema/unassigntsigkey.sql
+++ b/server/schema/unassigntsigkey.sql
@@ -7,7 +7,10 @@ DECLARE
 BEGIN
 	SELECT zone.id INTO domain_id_var FROM zone WHERE name = domain_name;
 	IF NOT FOUND THEN
-		RAISE EXCEPTION 'domain % not found', domain_name;
+		SELECT slavezone.id INTO domain_id_var FROM slavezone WHERE name = domain_name;
+		IF NOT FOUND THEN
+			RAISE EXCEPTION 'domain % not found', domain_name;
+		END IF;
 	END IF;
 
 	SELECT id INTO domainmetadata_id_var FROM domainmetadata WHERE domain_id = domain_id_var;


### PR DESCRIPTION
Fixed not being able to assign a TSIG key to a slave zone if the
slave zone doesn't have an entry in zones table.
Changed Assign and Unassign SQL functions to return domain id from
zone or slavezone table based on kind of transfer.
Changed domainmetadata trigger to add domainmetadata_id and
domain name to domainmetadata_change table.
Changed getdomainmetadata SQL function to use the domainmetadata_id
instead of domain id.
Changed Assign and Unassign PDNS functions to use domain name
instead of domain id and fetch local domain id from PDNS DB using
the domain name.

Amends PROD-2531.