### PR TITLE
Fix removing services when TSIG key is assigned

### DIFF
--- a/dyndns/Makefile.PL
+++ b/dyndns/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadyndns',
-   'VERSION' => '1.1.51',
+   'VERSION' => '1.1.52',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadyndns' ]
 );

--- a/dyndns/SPECS/atomiadns-dyndns.spec
+++ b/dyndns/SPECS/atomiadns-dyndns.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS DDNS server
 Name: atomiadns-dyndns
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -82,6 +82,8 @@ fi
 exit 0
 
 %changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52
 * Thu Jul 29 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.51-1
 - Bump version to 1.1.51
 * Tue Mar 02 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.50-1

--- a/dyndns/debian/changelog
+++ b/dyndns/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.52) hardy; urgency=low
+
+  * Bump version to 1.1.52
+
+ -- Nemanja Zivkovic <nemanja.zivkovic@atomia.com>  Mon, 27 Sep 2021 15:10:00 +0100
+
 atomiadns-dyndns (1.1.51) hardy; urgency=low
 
   * Bump version to 1.1.51

--- a/powerdns_sync/Makefile.PL
+++ b/powerdns_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::PowerDNSSyncer',
-   'VERSION' => '1.1.51',
+   'VERSION' => '1.1.52',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiapowerdnssync' ]
 );

--- a/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
+++ b/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS PowerDNS Sync application
 Name: atomiadns-powerdnssync
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -85,6 +85,8 @@ fi
 exit 0
 
 %changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52
 * Thu Jul 29 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.51-1
 - Bump version to 1.1.51
 * Tue Mar 02 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.50-1

--- a/powerdns_sync/bin/atomiapowerdnssync
+++ b/powerdns_sync/bin/atomiapowerdnssync
@@ -223,11 +223,11 @@ SWITCH: {
 				while (1) {
 					last if $syncer->updates_disabled();
 					$syncer->sync_dnssec_keys();
+					$syncer->reload_updated_domainmetadata();
 					$syncer->reload_updated_zones();
 					$syncer->reload_updated_slavezones();
 					$syncer->sync_zone_transfers();
 					$syncer->reload_updated_tsig_keys();
-					$syncer->reload_updated_domainmetadata();
 					sleep 10;
 				}
 			};

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-powerdnssync (1.1.52) hardy; urgency=low
+
+  * Bump version to 1.1.52
+
+ -- Nemanja Zivkovic <nemanja.zivkovic@atomia.com>  Mon, 27 Sep 2021 15:10:00 +0100
+
 atomiadns-powerdnssync (1.1.51) hardy; urgency=low
 
   * Bump version to 1.1.51

--- a/server/Makefile.PL
+++ b/server/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Server',
-   'VERSION' => '1.1.51',
+   'VERSION' => '1.1.52',
    'AUTHOR' => 'Jimmy Bergman <jimmy@pingdom.com>',
    'DIR' => [],
    'EXE_FILES' => [ 'bin/generate_private_key' ]

--- a/server/SPECS/atomiadns-api.spec
+++ b/server/SPECS/atomiadns-api.spec
@@ -5,7 +5,7 @@
 
 Summary: SOAP-server for Atomia DNS
 Name: atomiadns-api
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -85,6 +85,8 @@ fi
 exit 0
 
 %changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52
 * Thu Jul 29 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.51-1
 - Bump version to 1.1.51
 * Tue Mar 02 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.50-1

--- a/server/SPECS/atomiadns-client.spec
+++ b/server/SPECS/atomiadns-client.spec
@@ -5,7 +5,7 @@
 
 Summary: Command line client for Atomia DNS
 Name: atomiadns-client
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: Applications/Internet
@@ -53,6 +53,8 @@ cd ..
 %doc %{_mandir}/man1/dnssec_zsk_rollover.1.gz
 
 %changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52
 * Thu Jul 29 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.51-1
 - Bump version to 1.1.51
 * Tue Mar 02 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.50-1

--- a/server/SPECS/atomiadns-database.spec
+++ b/server/SPECS/atomiadns-database.spec
@@ -5,7 +5,7 @@
 
 Summary: Database schema for Atomia DNS
 Name: atomiadns-database
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -52,6 +52,8 @@ The Atomia DNS database schema.
 sh /usr/share/atomiadns/atomiadns-database.postinst.sh
 
 %changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52
 * Thu Jul 29 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.51-1
 - Bump version to 1.1.51
 * Tue Mar 02 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.50-1

--- a/server/SPECS/atomiadns-masterserver.spec
+++ b/server/SPECS/atomiadns-masterserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Complete master SOAP server for Atomia DNS
 Name: atomiadns-masterserver
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -18,7 +18,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildArch: noarch
 
-Requires: atomiadns-api >= 1.1.51 atomiadns-database >= 1.1.51
+Requires: atomiadns-api >= 1.1.52 atomiadns-database >= 1.1.52
 
 %description
 Complete master SOAP server for Atomia DNS
@@ -37,6 +37,8 @@ Complete master SOAP server for Atomia DNS
 %files
 
 %changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52
 * Thu Jul 29 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.51-1
 - Bump version to 1.1.51
 * Tue Mar 02 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.50-1

--- a/server/client/Makefile.PL
+++ b/server/client/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadnsclient',
-   'VERSION' => '1.1.51',
+   'VERSION' => '1.1.52',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadnsclient', 'dnssec_zsk_rollover' ]
 );

--- a/server/debian/changelog
+++ b/server/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-masterserver (1.1.52) hardy; urgency=low
+
+  * Bump version to 1.1.52
+
+ -- Nemanja Zivkovic <nemanja.zivkovic@atomia.com>  Mon, 27 Sep 2021 15:10:00 +0100
+
 atomiadns-masterserver (1.1.51) hardy; urgency=low
 
   * Bump version to 1.1.51

--- a/server/debian/control
+++ b/server/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-masterserver
 Architecture: all
-Depends: atomiadns-api (>= 1.1.51), atomiadns-database (>= 1.1.51)
+Depends: atomiadns-api (>= 1.1.52), atomiadns-database (>= 1.1.52)
 Description: Complete master SOAP server for Atomia DNS
 
 Package: atomiadns-api

--- a/syncer/Makefile.PL
+++ b/syncer/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Syncer',
-   'VERSION' => '1.1.51',
+   'VERSION' => '1.1.52',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadnssync' ]
 );

--- a/syncer/SPECS/atomiadns-nameserver.spec
+++ b/syncer/SPECS/atomiadns-nameserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS Sync application
 Name: atomiadns-nameserver
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -108,6 +108,8 @@ fi
 exit 0
 
 %changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52
 * Thu Jul 29 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.51-1
 - Bump version to 1.1.51
 * Tue Mar 02 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.50-1

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-nameserver (1.1.52) hardy; urgency=low
+
+  * Bump version to 1.1.52
+
+ -- Nemanja Zivkovic <nemanja.zivkovic@atomia.com>  Mon, 27 Sep 2021 15:10:00 +0100
+
 atomiadns-nameserver (1.1.51) hardy; urgency=low
 
   * Bump version to 1.1.51

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-webapp (1.1.52) hardy; urgency=low
+
+  * Bump version to 1.1.52
+
+ -- Nemanja Zivkovic <nemanja.zivkovic@atomia.com>  Mon, 27 Sep 2021 15:10:00 +0100
+
 atomiadns-webapp (1.1.51) hardy; urgency=low
 
   * Bump version to 1.1.51

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atomiadns-controlpanel",
-	"version": "1.1.51",
+	"version": "1.1.52",
 	"private": true,
 	"dependencies": {
 		"express":		"= 3.11.0",

--- a/zonefileimporter/Makefile.PL
+++ b/zonefileimporter/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadns_zoneimport',
-   'VERSION' => '1.1.51',
+   'VERSION' => '1.1.52',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadns_zoneimport' ]
 );

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-zoneimport (1.1.52) hardy; urgency=low
+
+  * Bump version to 1.1.52
+
+ -- Nemanja Zivkovic <nemanja.zivkovic@atomia.com>  Mon, 27 Sep 2021 15:10:00 +0100
+
 atomiadns-zoneimport (1.1.51) hardy; urgency=low
 
   * Bump version to 1.1.51


### PR DESCRIPTION
Fixed removing DnsZone service when a TSIG key is assigned to it.
Fixed removing DnsSlaveZone service when a TSIG key is
assigned to it.
Bumped version to 1.1.52.

Partially resolves PROD-2747 2/2.