### PR TITLE
Bump version to 1.1.52 for bind_sync

### DIFF
--- a/bind_sync/Makefile.PL
+++ b/bind_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Syncer',
-   'VERSION' => '1.1.51',
+   'VERSION' => '1.1.52',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadnssync' ]
 );

--- a/bind_sync/SPECS/atomiadns-bindsync.spec
+++ b/bind_sync/SPECS/atomiadns-bindsync.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS Sync application
 Name: atomiadns-bindsync
-Version: 1.1.51
+Version: 1.1.52
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -106,3 +106,7 @@ if [ "$1" = 0 ]; then
 	/usr/bin/systemctl disable atomiadns-atomiadnssync
 fi
 exit 0
+
+%changelog
+* Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1
+- Bump version to 1.1.52

--- a/bind_sync/debian/changelog
+++ b/bind_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-bindsync (1.1.52) hardy; urgency=low
+
+  * Bump version to 1.1.52
+
+ -- Nemanja Zivkovic <nemanja.zivkovic@atomia.com>  Mon, 27 Sep 2021 15:10:00 +0100
+
 atomiadns-bindsync (1.1.51) hardy; urgency=low
 
   * Bump version to 1.1.51


### PR DESCRIPTION
Bumped version to 1.1.52 for bind_sync.

Amends PROD-2747.