### PR TITLE
Fix TSIG key and domainmetadata tables reference

### DIFF
--- a/bind_sync/SPECS/atomiadns-bindsync.spec
+++ b/bind_sync/SPECS/atomiadns-bindsync.spec
@@ -112,7 +112,6 @@ exit 0
 %changelog
 * Tue Oct 12 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.54-1
 - Bump version to 1.1.54
-
 * Tue Oct 05 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.53-1
 - Bump version to 1.1.53
 * Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -622,7 +622,7 @@ if [ $retval != 0 ]; then
 				create_trigger "domainmetadata_trigger"
 			fi
 
-			if [ "$schema_version" -lt 90 ]; then
+			if [ "$schema_version" -lt 91 ]; then
 				execute_query "ALTER TABLE tsigkey DROP CONSTRAINT tsigkey_nameserver_group_id_fkey;"
 				execute_query "ALTER TABLE tsigkey ADD CONSTRAINT tsigkey_nameserver_group_id_fkey FOREIGN KEY (nameserver_group_id) REFERENCES nameserver_group;"
 				execute_query "ALTER TABLE domainmetadata DROP CONSTRAINT domainmetadata_nameserver_group_id_fkey;"

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -269,7 +269,7 @@ if [ $retval != 0 ]; then
 		echo "database zonedata already exist, but doesn't contain the atomiadns schema. You will have to make sure that the schema matches $basedir/schema manually"
 		exit 1
 	else
-		latest_version="90"
+		latest_version="91"
 
 		if [ "$schema_version" = "$latest_version" ]; then
 			echo "The installed schema is the latest version, keeping the database as it is."

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -622,6 +622,13 @@ if [ $retval != 0 ]; then
 				create_trigger "domainmetadata_trigger"
 			fi
 
+			if [ "$schema_version" -lt 90 ]; then
+				execute_query "ALTER TABLE tsigkey DROP CONSTRAINT tsigkey_nameserver_group_id_fkey;"
+				execute_query "ALTER TABLE tsigkey ADD CONSTRAINT tsigkey_nameserver_group_id_fkey FOREIGN KEY (nameserver_group_id) REFERENCES nameserver_group;"
+				execute_query "ALTER TABLE domainmetadata DROP CONSTRAINT domainmetadata_nameserver_group_id_fkey;"
+				execute_query "ALTER TABLE domainmetadata ADD CONSTRAINT domainmetadata_nameserver_group_id_fkey FOREIGN KEY (nameserver_group_id) REFERENCES nameserver_group;"
+			fi
+
 			set_schema_version "$latest_version"
 		else
 			echo "database zonedata already exist, but contains a bad schema version ($schema_version), this should never happen and indicates a bug."

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -40,7 +40,7 @@ CREATE TABLE atomiadns_schemaversion (
 	version INT
 );
 
-INSERT INTO atomiadns_schemaversion (version) VALUES (90);
+INSERT INTO atomiadns_schemaversion (version) VALUES (91);
 
 CREATE TABLE allow_zonetransfer (
         id SERIAL PRIMARY KEY NOT NULL,

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -343,7 +343,7 @@ EXECUTE PROCEDURE slavezone_update();
 
 CREATE TABLE tsigkey (
 	id BIGSERIAL PRIMARY KEY NOT NULL,
-	nameserver_group_id INT NOT NULL REFERENCES nameserver,
+	nameserver_group_id INT NOT NULL REFERENCES nameserver_group,
     name VARCHAR(255) NOT NULL UNIQUE CONSTRAINT tsig_name_format CHECK (name IS NULL OR name ~* '^[a-zA-Z0-9_-]*'),
 	secret VARCHAR(255) CONSTRAINT tsig_format CHECK (secret IS NULL OR secret ~* '^[a-zA-Z0-9+/=]*'),
 	algorithm VARCHAR(255)
@@ -383,7 +383,7 @@ EXECUTE PROCEDURE tsigkey_update();
 
 CREATE TABLE domainmetadata (
 	id BIGSERIAL PRIMARY KEY NOT NULL,
-	nameserver_group_id INT NOT NULL REFERENCES nameserver,
+	nameserver_group_id INT NOT NULL REFERENCES nameserver_group,
 	domain_id INT NOT NULL,
 	kind VARCHAR(255) NOT NULL CONSTRAINT kind_format CHECK (kind IN ('TSIG-ALLOW-AXFR','AXFR-MASTER-TSIG')),
     tsigkey_name VARCHAR(255) NOT NULL CONSTRAINT tsig_name_format CHECK (tsigkey_name ~* '^[a-zA-Z0-9_-]*')

--- a/syncer/SPECS/atomiadns-nameserver.spec
+++ b/syncer/SPECS/atomiadns-nameserver.spec
@@ -110,7 +110,6 @@ exit 0
 %changelog
 * Tue Oct 12 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.54-1
 - Bump version to 1.1.54
-
 * Tue Oct 05 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 1.1.53-1
 - Bump version to 1.1.53
 * Mon Sep 27 2021 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.52-1


### PR DESCRIPTION
Fixed TSIG key and domainmetadata tables reference nameserver
table instead of nameserver_group.

Resolves PROD-2758.