### PR TITLE
Fix unassign TSIG with same domain id

### DIFF
--- a/server/schema/unassigntsigkey.sql
+++ b/server/schema/unassigntsigkey.sql
@@ -4,19 +4,21 @@ CREATE OR REPLACE FUNCTION UnassignTSIGKey (
 DECLARE
 	domainmetadata_id_var bigint;
 	domain_id_var bigint;
+	kind_var varchar := 'TSIG-ALLOW-AXFR';
 BEGIN
 	SELECT zone.id INTO domain_id_var FROM zone WHERE name = domain_name;
 	IF NOT FOUND THEN
+		kind_var := 'AXFR-MASTER-TSIG';
 		SELECT slavezone.id INTO domain_id_var FROM slavezone WHERE name = domain_name;
 		IF NOT FOUND THEN
 			RAISE EXCEPTION 'domain % not found', domain_name;
 		END IF;
 	END IF;
 
-	SELECT id INTO domainmetadata_id_var FROM domainmetadata WHERE domain_id = domain_id_var;
+	SELECT id INTO domainmetadata_id_var FROM domainmetadata WHERE domain_id = domain_id_var AND kind = kind_var;
 	IF NOT FOUND THEN
 		RAISE EXCEPTION 'domainmetadata for domain % not found', domain_name;
 	END IF;
 
-	DELETE FROM domainmetadata WHERE domain_id = domain_id_var;
+	DELETE FROM domainmetadata WHERE domain_id = domain_id_var AND kind = kind_var;
 END; $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Fixed problem when unassigning TSIG key from slave and master zone
with the same domain ids.

Resolves PROD-2761.