### PR TITLE
Fix atomiadns postgresql 10 issues

### DIFF
--- a/powerdns_sync/debian/atomiadns-powerdns-database.postinst
+++ b/powerdns_sync/debian/atomiadns-powerdns-database.postinst
@@ -74,13 +74,7 @@ createschema() {
 			exit 1
 		fi
 
-		$mysql -e 'CREATE USER `'"$db_username"'`@`localhost` IDENTIFIED BY '"'$password'" > /dev/null 2>&1
-		if [ $? != 0 ]; then
-			echo "error creating powerdns database user, you will have to make sure that the schema matches $schemafile manually"
-			exit 1
-		fi
-
-		$mysql -e 'GRANT ALL PRIVILEGES ON powerdns.* TO `'"$db_username"'`@`localhost`' > /dev/null 2>&1
+		$mysql -e 'GRANT ALL ON powerdns.* TO `'"$db_username"'`@`localhost` IDENTIFIED BY '"'$password'" > /dev/null 2>&1
 		if [ $? != 0 ]; then
 			echo "error granting access to powerdns user, you will have to make sure that the schema matches $schemafile manually"
 			exit 1

--- a/powerdns_sync/debian/atomiadns-powerdns-database.postinst
+++ b/powerdns_sync/debian/atomiadns-powerdns-database.postinst
@@ -74,7 +74,13 @@ createschema() {
 			exit 1
 		fi
 
-		$mysql -e 'GRANT ALL ON powerdns.* TO `'"$db_username"'`@`localhost` IDENTIFIED BY '"'$password'" > /dev/null 2>&1
+		$mysql -e 'CREATE USER `'"$db_username"'`@`localhost` IDENTIFIED BY '"'$password'" > /dev/null 2>&1
+		if [ $? != 0 ]; then
+			echo "error creating powerdns database user, you will have to make sure that the schema matches $schemafile manually"
+			exit 1
+		fi
+
+		$mysql -e 'GRANT ALL PRIVILEGES ON powerdns.* TO `'"$db_username"'`@`localhost`' > /dev/null 2>&1
 		if [ $? != 0 ]; then
 			echo "error granting access to powerdns user, you will have to make sure that the schema matches $schemafile manually"
 			exit 1

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -75,6 +75,7 @@ createschema() {
 
 	psql_version=`$psql -qAt zonedata -c "show server_version_num" 2> /dev/null`
 
+	# create role
 	if $psql zonedata -t -c "SELECT * FROM pg_catalog.pg_user WHERE usename = '$db_username'" 2> /dev/null | grep "$db_username" > /dev/null; then
 		echo "The role with username $db_username already exists, ignoring."
 	else
@@ -92,30 +93,49 @@ createschema() {
 		fi
 	fi
 	
-	if [ $remote_db -eq 1 ]; then
-		existing_languages=`createlang -U $db_username -h $db_hostname -d zonedata -l 2>&1`
-		retval=$?
-	else
-		existing_languages=`$sudo createlang -d zonedata -l 2>&1`
-		retval=$?
-	fi
-
-	if [ $retval != 0 ]; then
-		echo "error finding existing languages in zonedata, you will have to make sure that the schema matches $basedir/schema manually"
-		exit 1
-	elif echo "$existing_languages" | grep plpgsql > /dev/null; then
-		echo "language plpgsql already added by default when zonedata was created, skipping"
-	else
+	# create language (plpgsql)
+	if [[ $psql_version -lt 100000 ]]; then	
 		if [ $remote_db -eq 1 ]; then
-			createlang -U $db_username -h $db_hostname -d zonedata plpgsql > /dev/null 2>&1
-			temp=$?
+			existing_languages=`createlang -U $db_username -h $db_hostname -d zonedata -l 2>&1`
+			retval=$?
 		else
-			$sudo createlang -d zonedata plpgsql > /dev/null 2>&1
-			temp=$?
+			existing_languages=`$sudo createlang -d zonedata -l 2>&1`
+			retval=$?
 		fi
-		if [ $temp != 0 ]; then
-			echo "error adding plpgsql as language in zonedata, you will have to make sure that the schema matches $basedir/schema manually"
+
+		if [ $retval != 0 ]; then
+			echo "Error finding existing languages in zonedata, you will have to make sure that the schema matches $basedir/schema manually"
 			exit 1
+		elif echo "$existing_languages" | grep plpgsql > /dev/null; then
+			echo "Language plpgsql already added by default when zonedata was created, skipping"
+		else
+			if [ $remote_db -eq 1 ]; then
+				createlang -U $db_username -h $db_hostname -d zonedata plpgsql > /dev/null 2>&1
+				temp=$?
+			else
+				$sudo createlang -d zonedata plpgsql > /dev/null 2>&1
+				temp=$?
+			fi
+			if [ $temp != 0 ]; then
+				echo "Error adding plpgsql as language in zonedata, you will have to make sure that the schema matches $basedir/schema manually"
+				exit 1
+			fi
+		fi
+	else
+		existing_languages=`$psql -qAt zonedata -c "SELECT lanname FROM pg_language" 2> /dev/null`
+		retval=$?
+
+		if [ $retval != 0 ]; then
+			echo "Error finding existing languages, you will have to make sure that the schema matches $basedir/schema manually"
+			exit 1
+		elif echo "$existing_languages" | grep plpgsql > /dev/null; then
+			echo "Language plpgsql already added by default when zonedata was created, skipping"
+		else
+			$psql -qAt zonedata -c "CREATE LANGUAGE plpgsql" 2> /dev/null
+			if [ $? != 0 ]; then
+				echo "Error adding plpgsql as language in zonedata, you will have to make sure that the schema matches $basedir/schema manually"
+				exit 1
+			fi
 		fi
 	fi
 

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -131,7 +131,7 @@ createschema() {
 		elif echo "$existing_languages" | grep plpgsql > /dev/null; then
 			echo "Language plpgsql already added by default when zonedata was created, skipping"
 		else
-			$psql -qAt zonedata -c "CREATE LANGUAGE plpgsql" 2> /dev/null
+			$psql -qAt zonedata -c "CREATE EXTENSION plpgsql" 2> /dev/null
 			if [ $? != 0 ]; then
 				echo "Error adding plpgsql as language in zonedata, you will have to make sure that the schema matches $basedir/schema manually"
 				exit 1

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -81,7 +81,7 @@ createschema() {
 	else
 		echo "Autogenerating the $db_username role"
 
-		if [[ $psql_version -lt 100000 ]]; then
+		if [ $psql_version -lt 100000 ]; then
 			$psql zonedata -c "CREATE ROLE $db_username WITH LOGIN UNENCRYPTED PASSWORD '$password' SUPERUSER" > /dev/null 2>&1
 		else
 			$psql zonedata -c "CREATE ROLE $db_username WITH LOGIN PASSWORD '$password' SUPERUSER" > /dev/null 2>&1
@@ -94,7 +94,7 @@ createschema() {
 	fi
 	
 	# create language (plpgsql)
-	if [[ $psql_version -lt 100000 ]]; then	
+	if [ $psql_version -lt 100000 ]; then	
 		if [ $remote_db -eq 1 ]; then
 			existing_languages=`createlang -U $db_username -h $db_hostname -d zonedata -l 2>&1`
 			retval=$?

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -73,12 +73,19 @@ createschema() {
 		sed -i -e "s/%password/$password/g" /etc/atomiadns.conf || exit 1
 	fi
 
+	psql_version=`$psql -qAt zonedata -c "show server_version_num" 2> /dev/null`
+
 	if $psql zonedata -t -c "SELECT * FROM pg_catalog.pg_user WHERE usename = '$db_username'" 2> /dev/null | grep "$db_username" > /dev/null; then
 		echo "The role with username $db_username already exists, ignoring."
 	else
 		echo "Autogenerating the $db_username role"
 
-		$psql zonedata -c "CREATE ROLE $db_username WITH LOGIN UNENCRYPTED PASSWORD '$password' SUPERUSER" > /dev/null 2>&1
+		if [[ $psql_version -lt 100000 ]]; then
+			$psql zonedata -c "CREATE ROLE $db_username WITH LOGIN UNENCRYPTED PASSWORD '$password' SUPERUSER" > /dev/null 2>&1
+		else
+			$psql zonedata -c "CREATE ROLE $db_username WITH LOGIN PASSWORD '$password' SUPERUSER" > /dev/null 2>&1
+		fi
+		
 		if [ $? != 0 ]; then
 			echo "error creating role atomiadns, you will have to make sure that the schema matches $basedir/schema manually"
 			exit 1


### PR DESCRIPTION
Removed keyword UNENCRYPTED from atomiadns
database post installation file.
Fixed createlang to work with postgresql 10 in atomiadns
database post installation file.

Resolves PROD-2823
