### PR TITLE
Prepare AtomiaDNS for Ubuntu 20.04

### DIFF
--- a/bind_sync/debian/control
+++ b/bind_sync/debian/control
@@ -8,5 +8,5 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-bindsync
 Architecture: all
-Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libmoose-perl, libberkeleydb-perl
+Depends: perl-modules, perl-base, libconfig-general-perl, libsoap-lite-perl, libmoose-perl
 Description: Atomia DNS Sync application

--- a/powerdns_sync/debian/atomiadns-powerdns-database.postinst
+++ b/powerdns_sync/debian/atomiadns-powerdns-database.postinst
@@ -74,7 +74,13 @@ createschema() {
 			exit 1
 		fi
 
-		$mysql -e 'GRANT ALL ON powerdns.* TO `'"$db_username"'`@`localhost` IDENTIFIED BY '"'$password'" > /dev/null 2>&1
+		$mysql -e 'CREATE USER `'"$db_username"'`@`localhost` IDENTIFIED BY '"'$password'" > /dev/null 2>&1
+		if [ $? != 0 ]; then
+			echo "error creating powerdns database user, you will have to make sure that the schema matches $schemafile manually"
+			exit 1
+		fi
+
+		$mysql -e 'GRANT ALL PRIVILEGES ON powerdns.* TO `'"$db_username"'`@`localhost`' > /dev/null 2>&1
 		if [ $? != 0 ]; then
 			echo "error granting access to powerdns user, you will have to make sure that the schema matches $schemafile manually"
 			exit 1

--- a/powerdns_sync/schema/powerdns.sql
+++ b/powerdns_sync/schema/powerdns.sql
@@ -244,7 +244,7 @@ CREATE TABLE comments (
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) NOT NULL,
-  comment               VARCHAR(64000) NOT NULL,
+  comment               VARCHAR(1024) NOT NULL,
   PRIMARY KEY(id)
 ) Engine=InnoDB;
 

--- a/server/debian/rules
+++ b/server/debian/rules
@@ -27,6 +27,9 @@ endif
 ifeq ($(shell lsb_release -r |  cut -f2 ),18.04)
         SUBSTVARS = -Vdist:Depends=""
 endif
+ifeq ($(shell lsb_release -r |  cut -f2 ),20.04)
+        SUBSTVARS = -Vdist:Depends=""
+endif
 
 build: build-stamp
 build-stamp:


### PR DESCRIPTION
Split GRANT privileges/create user into two separate commands
in powerdns database postinst file.
Removed apache2-mpm-prefork dependency on Ubuntu 20.04.
Removed libberkeleydb-perl dependency from bind sync.

Resolves PROD-2832