### PR TITLE
Add support for suspending the zone

### DIFF
--- a/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
+++ b/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
@@ -246,7 +246,7 @@ sub add_zone {
 			}
 
 			my $disable_records = 0;
-			if ($zone_status eq 'suspended') {
+			if (defined($zone_status) && $zone_status eq 'suspended') {
 				$disable_records = 1;
 			}
 

--- a/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
+++ b/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
@@ -146,6 +146,7 @@ sub add_zone {
 	my $zone_type = shift;
 	my $presigned = shift;
 	my $nsec_type = shift;
+	my $zone_status = shift;
 
 	die "bad indata to add_zone" unless defined($zone) && ref($zone) eq "HASH" && defined($records) && ref($records) eq "ARRAY";
 
@@ -243,6 +244,14 @@ sub add_zone {
 			{
 				$self->dbi->do($query) || die "error inserting record batch $batch, query=$query: $DBI::errstr";
 			}
+
+			my $disable_records = 0;
+			if ($zone_status eq 'suspended') {
+				$disable_records = 1;
+			}
+
+			$query = "UPDATE records SET disabled = $disable_records WHERE domain_id = $domain_id AND type NOT IN ('NS', 'SOA')";
+			$self->dbi->do($query) || die "error updating record disabled property, query=$query: $DBI::errstr";
 		}
 
 		$self->dbi->commit();

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -664,6 +664,12 @@ if [ $retval != 0 ]; then
 				recreate_procedure "unassigntsigkey"
 			fi
 
+			if [ "$schema_version" -lt 94 ]; then
+				alter_table_addcolumn "zone" "status VARCHAR DEFAULT 'active'"
+				recreate_procedure "getzonestatusbulk"
+				recreate_procedure "setzonestatus"
+			fi
+
 			set_schema_version "$latest_version"
 		else
 			echo "database zonedata already exist, but contains a bad schema version ($schema_version), this should never happen and indicates a bug."

--- a/server/debian/atomiadns-database.postinst
+++ b/server/debian/atomiadns-database.postinst
@@ -296,7 +296,7 @@ if [ $retval != 0 ]; then
 		echo "database zonedata already exist, but doesn't contain the atomiadns schema. You will have to make sure that the schema matches $basedir/schema manually"
 		exit 1
 	else
-		latest_version="93"
+		latest_version="94"
 
 		if [ "$schema_version" = "$latest_version" ]; then
 			echo "The installed schema is the latest version, keeping the database as it is."

--- a/server/generate_wsdl.sh
+++ b/server/generate_wsdl.sh
@@ -74,6 +74,8 @@ methodawk='BEGIN {
 	methods["GetDomainMetaData"] = "Gets data for assigning a TSIG key.";
 	methods["MarkDomainMetaDataUpdated"] = "Marks a domain meta data as updated after asigning a TSIG key.";
 	methods["UnassignTSIGKey"] = "Unassigns a TSIG key to a domain.";
+	methods["GetZoneStatusBulk"] = "Gets zones status.";
+	methods["SetZoneStatus"] = "Sets zone status.";
 	methods["Noop"] = "Do nothing. Meant for generating token without doing anything when authenticating.";
 }'
 

--- a/server/lib/Atomia/DNS/Signatures.pm
+++ b/server/lib/Atomia/DNS/Signatures.pm
@@ -77,7 +77,9 @@ our $signatures = {
 	"MarkDomainMetaDataUpdated" => "void bigint string string",
 	"UnassignTSIGKey" => "void string",
 	"TestOp" => "void string string string string",
-	"Noop" => "string"
+	"Noop" => "string",
+	"SetZoneStatus" => "void string string",
+	"GetZoneStatusBulk" => "zonestatusarray array[string]"
 };
 
 our $authorization_rules = {

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -40,7 +40,7 @@ CREATE TABLE atomiadns_schemaversion (
 	version INT
 );
 
-INSERT INTO atomiadns_schemaversion (version) VALUES (93);
+INSERT INTO atomiadns_schemaversion (version) VALUES (94);
 
 CREATE TABLE allow_zonetransfer (
         id SERIAL PRIMARY KEY NOT NULL,

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -434,6 +434,3 @@ ON domainmetadata
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW
 EXECUTE PROCEDURE domainmetadata_update();
-
-ALTER TABLE zone
-ADD COLUMN status VARCHAR DEFAULT 'active';

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -434,3 +434,6 @@ ON domainmetadata
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW
 EXECUTE PROCEDURE domainmetadata_update();
+
+ALTER TABLE zone
+ADD COLUMN status VARCHAR DEFAULT 'active';

--- a/server/schema/getzonestatusbulk.sql
+++ b/server/schema/getzonestatusbulk.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION GetZoneStatusBulk(
+	zonenames varchar[],
+	out zonename varchar,
+	out zonestatus varchar
+) RETURNS SETOF record AS $$
+DECLARE
+
+BEGIN
+	IF zonenames IS NOT NULL AND array_length(zonenames, 1) > 0 THEN
+		FOR i IN array_lower(zonenames, 1) .. array_upper(zonenames, 1) LOOP
+					zonename := zonenames[i];
+					SELECT status INTO zonestatus FROM zone WHERE name = zonenames[i];
+					IF NOT FOUND THEN
+									RAISE EXCEPTION 'zone % not found', zonename;
+					END IF;
+		RETURN NEXT;
+		END LOOP;
+	END IF;
+
+	RETURN;
+END; $$ LANGUAGE plpgsql;

--- a/server/schema/setzonestatus.sql
+++ b/server/schema/setzonestatus.sql
@@ -10,7 +10,7 @@ BEGIN
                 RAISE EXCEPTION 'zone % not found', zonename;
         END IF;
 
-				IF zonestatus != 'active' OR zonestatus != 'suspended' THEN
+				IF zonestatus != 'active' AND zonestatus != 'suspended' THEN
 					RAISE EXCEPTION 'zonestatus % is not allowed', zonestatus;
         END IF;
 

--- a/server/schema/setzonestatus.sql
+++ b/server/schema/setzonestatus.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION SetZoneStatus(
+	zonename varchar,
+	zonestatus varchar
+) RETURNS void AS $$
+DECLARE
+	zone_id int;
+BEGIN
+				SELECT id INTO zone_id FROM zone WHERE name = zonename;
+        IF NOT FOUND THEN
+                RAISE EXCEPTION 'zone % not found', zonename;
+        END IF;
+
+				IF zonestatus != 'active' OR zonestatus != 'suspended' THEN
+					RAISE EXCEPTION 'zonestatus % is not allowed', zonestatus;
+        END IF;
+
+				UPDATE zone SET status = zonestatus WHERE id = zone_id;
+
+	RETURN;
+END; $$ LANGUAGE plpgsql;

--- a/server/wsdl-atomiadns.wsdl
+++ b/server/wsdl-atomiadns.wsdl
@@ -1487,10 +1487,12 @@ atomiaDomainMetaDataItem is a struct with the following members:
 
 			<xsd:element name="AddTSIGKey">
 				<xsd:complexType>
-					<xsd:element minOccurs="1" maxOccurs="1" name="tsig_name" type="xsd:string"><xsd:annotation><xsd:documentation>the name of the TSIG key</xsd:documentation></xsd:annotation></xsd:element>
-					<xsd:element minOccurs="1" maxOccurs="1" name="tsig_secret" type="xsd:string"><xsd:annotation><xsd:documentation>the secret hash for the key</xsd:documentation></xsd:annotation></xsd:element>
-					<xsd:element minOccurs="1" maxOccurs="1" name="tsig_algorithm" type="xsd:string"><xsd:annotation><xsd:documentation>the algorithm used for the hash</xsd:documentation></xsd:annotation></xsd:element>
-					<xsd:element minOccurs="1" maxOccurs="1" name="nameserver_group_name" type="xsd:string"><xsd:annotation><xsd:documentation>the nameserver group that should host the zone</xsd:documentation></xsd:annotation></xsd:element>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="tsig_name" type="xsd:string"><xsd:annotation><xsd:documentation>the name of the TSIG key</xsd:documentation></xsd:annotation></xsd:element>
+						<xsd:element minOccurs="1" maxOccurs="1" name="tsig_secret" type="xsd:string"><xsd:annotation><xsd:documentation>the secret hash for the key</xsd:documentation></xsd:annotation></xsd:element>
+						<xsd:element minOccurs="1" maxOccurs="1" name="tsig_algorithm" type="xsd:string"><xsd:annotation><xsd:documentation>the algorithm used for the hash</xsd:documentation></xsd:annotation></xsd:element>
+						<xsd:element minOccurs="1" maxOccurs="1" name="nameserver_group_name" type="xsd:string"><xsd:annotation><xsd:documentation>the nameserver group that should host the zone</xsd:documentation></xsd:annotation></xsd:element>
+					</xsd:all>
 				</xsd:complexType>
 			</xsd:element>
 
@@ -1653,20 +1655,18 @@ atomiaDomainMetaDataItem is a struct with the following members:
 				</xsd:complexType>
 			</xsd:element>
 
-						<xsd:element name="SetZoneStatus">
+			<xsd:element name="SetZoneStatus">
 				<xsd:complexType>
 					<xsd:all>
 						<xsd:element minOccurs="1" maxOccurs="1" name="zone" type="xsd:string"><xsd:annotation><xsd:documentation>the name of the zone</xsd:documentation></xsd:annotation></xsd:element>
-						<xsd:element minOccurs="1" maxOccurs="1" name="status" type="xsd:int"><xsd:annotation><xsd:documentation>suspended if the zone should be suspended or active if it is to be active</xsd:documentation></xsd:annotation></xsd:element>
+						<xsd:element minOccurs="1" maxOccurs="1" name="status" type="xsd:string"><xsd:annotation><xsd:documentation>suspended if the zone should be suspended or active if it is to be active</xsd:documentation></xsd:annotation></xsd:element>
 					</xsd:all>
 				</xsd:complexType>
 			</xsd:element>
 
 			<xsd:element name="SetZoneStatusResponse">
 				<xsd:complexType>
-					<xsd:all>
-						<xsd:element minOccurs="1" maxOccurs="1" name="zone" type="xsd:string"/>
-					</xsd:all>
+					<xsd:all />
 				</xsd:complexType>
 			</xsd:element>
 

--- a/server/wsdl-atomiadns.wsdl
+++ b/server/wsdl-atomiadns.wsdl
@@ -428,6 +428,27 @@ atomiaDomainMetaDataItem is a struct with the following members:
 				</xsd:all>
 			</xsd:complexType>
 
+			<xsd:complexType name="atomiaZoneStatus">
+				<xsd:annotation>
+					<xsd:documentation> atomiaZoneStatus is a struct with the following members: || Member ||
+						Type || Description || | name | string | the name of the zone | | zonestatus | string | active the
+						zone is active, suspended the zone is suspended | {excerpt:hidden=true}{excerpt} </xsd:documentation>
+				</xsd:annotation>
+				<xsd:all>
+					<xsd:element minOccurs="1" maxOccurs="1" name="name" type="xsd:string" />
+					<xsd:element minOccurs="1" maxOccurs="1" name="zonestatus" type="xsd:string" />
+				</xsd:all>
+			</xsd:complexType>
+
+			<xsd:complexType name="atomiaZoneStatusArray">
+				<xsd:annotation>
+					<xsd:documentation>atomiaZoneStatusArray is an array of atomiaZoneStatus-structs.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:sequence>
+					<xsd:element minOccurs="1" maxOccurs="unbounded" name="item" type="atomiaZoneStatus" />
+				</xsd:sequence>
+			</xsd:complexType>
+
 			<xsd:element name="GetUpdatesDisabled">
 				<xsd:complexType>
 					<xsd:all />
@@ -1632,6 +1653,39 @@ atomiaDomainMetaDataItem is a struct with the following members:
 				</xsd:complexType>
 			</xsd:element>
 
+						<xsd:element name="SetZoneStatus">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="zone" type="xsd:string"><xsd:annotation><xsd:documentation>the name of the zone</xsd:documentation></xsd:annotation></xsd:element>
+						<xsd:element minOccurs="1" maxOccurs="1" name="status" type="xsd:int"><xsd:annotation><xsd:documentation>suspended if the zone should be suspended or active if it is to be active</xsd:documentation></xsd:annotation></xsd:element>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
+			<xsd:element name="SetZoneStatusResponse">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="zone" type="xsd:string"/>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
+			<xsd:element name="GetZoneStatusBulk">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="zones" type="xsdAtomiaStringArray"><xsd:annotation><xsd:documentation>the name of the zones</xsd:documentation></xsd:annotation></xsd:element>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
+			<xsd:element name="GetZoneStatusBulkResponse">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="zonestatusarray" type="atomiaZoneStatusArray"/>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
 			<xsd:element name="Noop">
 				<xsd:complexType>
 					<xsd:all />
@@ -2312,6 +2366,24 @@ atomiaDomainMetaDataItem is a struct with the following members:
 		<part name="parameters" element="tns:UnassignTSIGKeyResponse"/>
 	</message>
 
+	<message name="SetZoneStatusInput">
+		<documentation>Set zone status.</documentation>
+		<part name="parameters" element="tns:SetZoneStatus"/>
+	</message>
+
+	<message name="SetZoneStatusOutput">
+		<part name="parameters" element="tns:SetZoneStatusResponse"/>
+	</message>
+
+	<message name="GetZoneStatusBulkInput">
+		<documentation>Set zone status.</documentation>
+		<part name="parameters" element="tns:GetZoneStatusBulk"/>
+	</message>
+
+	<message name="GetZoneStatusBulkOutput">
+		<part name="parameters" element="tns:GetZoneStatusBulkResponse"/>
+	</message>
+
 	<message name="NoopInput">
 		<documentation>Do nothing. Meant for generating token without doing anything when authenticating.</documentation>
 		<part name="parameters" element="tns:Noop"/>
@@ -2964,6 +3036,24 @@ atomiaDomainMetaDataItem is a struct with the following members:
 		<operation name="UnassignTSIGKey">
 			<input message="tns:UnassignTSIGKeyInput"/>
 			<output message="tns:UnassignTSIGKeyOutput"/>
+			<fault message="tns:LogicalErrorFaultMessage" name="LogicalErrorFault" />
+			<fault message="tns:InvalidParametersErrorFaultMessage" name="InvalidParametersErrorFault" />
+			<fault message="tns:SystemErrorFaultMessage" name="SystemErrorFault" />
+			<fault message="tns:InternalErrorFaultMessage" name="InternalErrorFault" />
+		</operation>
+
+		<operation name="SetZoneStatus">
+			<input message="tns:SetZoneStatusInput"/>
+			<output message="tns:SetZoneStatusOutput"/>
+			<fault message="tns:LogicalErrorFaultMessage" name="LogicalErrorFault" />
+			<fault message="tns:InvalidParametersErrorFaultMessage" name="InvalidParametersErrorFault" />
+			<fault message="tns:SystemErrorFaultMessage" name="SystemErrorFault" />
+			<fault message="tns:InternalErrorFaultMessage" name="InternalErrorFault" />
+		</operation>
+
+		<operation name="GetZoneStatusBulk">
+			<input message="tns:GetZoneStatusBulkInput"/>
+			<output message="tns:GetZoneStatusBulkOutput"/>
 			<fault message="tns:LogicalErrorFaultMessage" name="LogicalErrorFault" />
 			<fault message="tns:InvalidParametersErrorFaultMessage" name="InvalidParametersErrorFault" />
 			<fault message="tns:SystemErrorFaultMessage" name="SystemErrorFault" />
@@ -3767,6 +3857,28 @@ atomiaDomainMetaDataItem is a struct with the following members:
 		<operation name="UnassignTSIGKey">
 			<documentation>Removes a TSIG key.</documentation>
 			<soap:operation soapAction="urn:Atomia::DNS::Server#UnassignTSIGKey"/>
+			<input><soap:body use="literal"/></input>
+			<output><soap:body use="literal"/></output>
+			<fault name="LogicalErrorFault"><soap:fault name="LogicalErrorFault" use="literal" /></fault>
+			<fault name="InvalidParametersErrorFault"><soap:fault name="InvalidParametersErrorFault" use="literal" /></fault>
+			<fault name="SystemErrorFault"><soap:fault name="SystemErrorFault" use="literal" /></fault>
+			<fault name="InternalErrorFault"><soap:fault name="InternalErrorFault" use="literal" /></fault>
+		</operation>
+
+		<operation name="SetZoneStatus">
+			<documentation>Set the zone status.</documentation>
+			<soap:operation soapAction="urn:Atomia::DNS::Server#SetZoneStatus"/>
+			<input><soap:body use="literal"/></input>
+			<output><soap:body use="literal"/></output>
+			<fault name="LogicalErrorFault"><soap:fault name="LogicalErrorFault" use="literal" /></fault>
+			<fault name="InvalidParametersErrorFault"><soap:fault name="InvalidParametersErrorFault" use="literal" /></fault>
+			<fault name="SystemErrorFault"><soap:fault name="SystemErrorFault" use="literal" /></fault>
+			<fault name="InternalErrorFault"><soap:fault name="InternalErrorFault" use="literal" /></fault>
+		</operation>
+
+		<operation name="GetZoneStatusBulk">
+			<documentation>Get the zone status bulk.</documentation>
+			<soap:operation soapAction="urn:Atomia::DNS::Server#GetZoneStatusBulk"/>
 			<input><soap:body use="literal"/></input>
 			<output><soap:body use="literal"/></output>
 			<fault name="LogicalErrorFault"><soap:fault name="LogicalErrorFault" use="literal" /></fault>

--- a/server/wsdl-type-schema.xsd
+++ b/server/wsdl-type-schema.xsd
@@ -1547,6 +1547,39 @@ atomiaZSKInfo is a struct with the following members:
 				</xsd:complexType>
 			</xsd:element>
 
+			<xsd:element name="SetZoneStatus">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="zone" type="xsd:string"><xsd:annotation><xsd:documentation>the name of the zone</xsd:documentation></xsd:annotation></xsd:element>
+						<xsd:element minOccurs="1" maxOccurs="1" name="status" type="xsd:string"><xsd:annotation><xsd:documentation>suspended if the zone should be suspended or active if it is to be active</xsd:documentation></xsd:annotation></xsd:element>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
+			<xsd:element name="SetZoneStatusResponse">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="status" type="xsd:string"/>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
+			<xsd:element name="GetZoneStatusBulk">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="zones" type="xsdAtomiaStringArray"><xsd:annotation><xsd:documentation>the name of the zones</xsd:documentation></xsd:annotation></xsd:element>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
+			<xsd:element name="GetZoneStatusBulkResponse">
+				<xsd:complexType>
+					<xsd:all>
+						<xsd:element minOccurs="1" maxOccurs="1" name="zonestatusarray" type="atomiaZoneStatusArray"/>
+					</xsd:all>
+				</xsd:complexType>
+			</xsd:element>
+
 			<xsd:element name="Noop">
 				<xsd:complexType>
 					<xsd:all />


### PR DESCRIPTION
Next changes are done for adding support for suspending the zone:

* Added a new column ('status') in the table zone.

* Added API method SetZoneStatus that changes the zone status. This method has 2 string arguments zonename and zonestatus. The zonename argument is representing the zone that is being updated, and the zonestatus argument ('active', 'suspended') is representing a new zone status.

* Added API method GetZoneStatusBulk that will get the status of the zones. The input parameter is an array of zone names, and the output is an array of objects (zonename, zonestatus).

Resolves PROD-2913.

ChangeLog:

* [IMPROVEMENT] Added support for suspending the zone.