### PR TITLE
Fix synchronization for large zones

### DIFF
--- a/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
+++ b/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
@@ -239,7 +239,10 @@ sub add_zone {
 				$first_in_batch = 0;
 			}
 
-			$self->dbi->do($query) || die "error inserting record batch $batch, query=$query: $DBI::errstr";
+			if($first_in_batch == 0)
+			{
+				$self->dbi->do($query) || die "error inserting record batch $batch, query=$query: $DBI::errstr";
+			}
 		}
 
 		$self->dbi->commit();


### PR DESCRIPTION
Fixed SQL syntax error when a zone has 1000 or
more duplicate records.

Resolves PROD-2924

ChangeLog:
* [FIX] Fixed synchronization for zones with more than 1000 records.