### PR TITLE
Add support for PowerDNS 4.7 in AtomiaDNS

### DIFF
--- a/powerdns_sync/debian/atomiadns-powerdns-database.postinst
+++ b/powerdns_sync/debian/atomiadns-powerdns-database.postinst
@@ -126,7 +126,7 @@ if [ $showdb_ret = 0 ] && [ -n "$db_exists" ]; then
 			exit 1
 		fi
 	else
-		latest_version="17"
+		latest_version="18"
 
 		if [ "$schema_version" = "$latest_version" ]; then
 			echo "The installed schema is the latest version ($latest_version), keeping the database as it is."
@@ -471,6 +471,13 @@ ALTER VIEW powerdns.cryptokeys AS
 						JOIN powerdns.global_cryptokeys c
 					)
 					WHERE d.type IN ('NATIVE', 'MASTER');"
+			fi
+
+			if [ "$schema_version" -lt 18 ]; then
+				execute_query "ALTER TABLE domains ADD options VARCHAR(64000) DEFAULT NULL;"
+				execute_query "ALTER TABLE domains ADD catalog VARCHAR(255) DEFAULT NULL;"
+				execute_query "ALTER TABLE domains MODIFY type VARCHAR(8) NOT NULL;"
+				execute_query "CREATE INDEX catalog_idx ON domains(catalog);"
 			fi
 
 			set_schema_version "$latest_version"

--- a/powerdns_sync/schema/powerdns.sql
+++ b/powerdns_sync/schema/powerdns.sql
@@ -1,7 +1,7 @@
 -- # Our versioning table
 DROP TABLE IF EXISTS powerdns_schemaversion;
 CREATE TABLE powerdns_schemaversion (version INT);
-INSERT INTO powerdns_schemaversion VALUES (17);
+INSERT INTO powerdns_schemaversion VALUES (18);
 
 -- MySQL dump 10.13  Distrib 5.1.41, for debian-linux-gnu (x86_64)
 --

--- a/powerdns_sync/schema/powerdns.sql
+++ b/powerdns_sync/schema/powerdns.sql
@@ -496,3 +496,9 @@ FROM (
   JOIN powerdns.global_cryptokeys c
 )
 WHERE d.type IN ('NATIVE', 'MASTER');
+
+ALTER TABLE domains ADD options VARCHAR(64000) DEFAULT NULL;
+ALTER TABLE domains ADD catalog VARCHAR(255) DEFAULT NULL;
+ALTER TABLE domains MODIFY type VARCHAR(8) NOT NULL;
+
+CREATE INDEX catalog_idx ON domains(catalog);


### PR DESCRIPTION
Added support for PowerDNS 4.7 in AtomiaDNS.

Resolves PROD-2927

ChangeLog:

* [FIX] Added support for PowerDNS 4.7 in AtomiaDNS.