### PR TITLE
Fix GetZoneStatus when zone doesn't exist

### DIFF
--- a/powerdns_sync/lib/Atomia/DNS/PowerDNSSyncer.pm
+++ b/powerdns_sync/lib/Atomia/DNS/PowerDNSSyncer.pm
@@ -119,6 +119,11 @@ sub reload_updated_zones {
 	my $zonestatusarray = $self->soap->GetZoneStatusBulk($changes_to_keep_name);
 	$zonestatusarray = $zonestatusarray->result;
 
+	my $zone_status_hash = {};
+	foreach my $zone_status (@$zonestatusarray) {
+		$zone_status_hash->{$zone_status->{'zonename'}} = $zone_status->{'zonestatus'};
+	}
+
 	if (scalar(@$changes_to_keep) > 0) {
 		$self->soap->MarkAllUpdatedExceptBulk($changes_to_keep_name, $changes_to_keep);
 	}
@@ -149,11 +154,8 @@ sub reload_updated_zones {
 
 				my $zone_name = $zone->{"name"};
 				my $zone_status = 'active';
-
-				foreach my $zonestatusitem (@zonestatusbatch) {
-					if ($zone_name eq $zonestatusitem->{zonename}) {
-						$zone_status = $zonestatusitem->{zonestatus};
-					}
+				if(exists($zone_status_hash->{$zone_name}) && $zone_status_hash->{$zone_name} eq "suspended"){
+					$zone_status = $zone_status_hash->{$zone_name};
 				}
 
 				if (defined($self->config->{"powerdns_presigned_dnssec"}) && $self->config->{"powerdns_presigned_dnssec"} eq "1") {

--- a/powerdns_sync/lib/Atomia/DNS/PowerDNSSyncer.pm
+++ b/powerdns_sync/lib/Atomia/DNS/PowerDNSSyncer.pm
@@ -121,7 +121,9 @@ sub reload_updated_zones {
 
 	my $zone_status_hash = {};
 	foreach my $zone_status (@$zonestatusarray) {
-		$zone_status_hash->{$zone_status->{'zonename'}} = $zone_status->{'zonestatus'};
+		if(defined($zone_status->{'zonename'}) && defined($zone_status->{'zonestatus'})){
+			$zone_status_hash->{$zone_status->{'zonename'}} = $zone_status->{'zonestatus'};
+		}
 	}
 
 	if (scalar(@$changes_to_keep) > 0) {
@@ -136,7 +138,6 @@ sub reload_updated_zones {
 		$num = $bulk_size if $num > $bulk_size;
 
 		my @batch = @{$zones}[$offset .. ($offset + $num - 1)];
-		my @zonestatusbatch = @{$zonestatusarray};
 
 		my @get_zone_bulk_arg = map { $_->{"name"} } @batch;
 		my $fetched_records_for_zones = $self->fetch_records_for_zones(\@get_zone_bulk_arg);

--- a/server/schema/getzonestatusbulk.sql
+++ b/server/schema/getzonestatusbulk.sql
@@ -8,11 +8,11 @@ DECLARE
 BEGIN
 	IF zonenames IS NOT NULL AND array_length(zonenames, 1) > 0 THEN
 		FOR i IN array_lower(zonenames, 1) .. array_upper(zonenames, 1) LOOP
-					zonename := zonenames[i];
-					SELECT status INTO zonestatus FROM zone WHERE name = zonenames[i];
-					IF NOT FOUND THEN
-									RAISE EXCEPTION 'zone % not found', zonename;
-					END IF;
+			zonename := zonenames[i];
+			SELECT status INTO zonestatus FROM zone WHERE name = zonenames[i];
+			IF NOT FOUND THEN
+				zonestatus := 'nonexistent';
+			END IF;
 		RETURN NEXT;
 		END LOOP;
 	END IF;


### PR DESCRIPTION
Changed GetZoneStatus method to return 'nonexistent'
state instead of an error when a zone doesn't exist.
Improved performance in the powerdnssync.

Amends PROD-2913

ChangeLog:
/