### PR TITLE
Fix missing column when atomia dns is installed

### DIFF
--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -131,7 +131,7 @@ CREATE TABLE zone (
         name VARCHAR(255) NOT NULL UNIQUE CONSTRAINT zone_format CHECK (name ~* '^([a-z0-9_][a-z0-9_-]*)([.][a-z0-9_][a-z0-9_-]*)*$'),
 	nameserver_group_id INT NOT NULL REFERENCES nameserver_group,
 	account_id INT NULL REFERENCES account,
-	status VARCHAR DEFAULT 'active'
+	status VARCHAR(32) DEFAULT 'active'
 );
 
 CREATE TABLE slavezone (

--- a/server/schema/ddl.sql
+++ b/server/schema/ddl.sql
@@ -130,7 +130,8 @@ CREATE TABLE zone (
         id BIGSERIAL PRIMARY KEY NOT NULL,
         name VARCHAR(255) NOT NULL UNIQUE CONSTRAINT zone_format CHECK (name ~* '^([a-z0-9_][a-z0-9_-]*)([.][a-z0-9_][a-z0-9_-]*)*$'),
 	nameserver_group_id INT NOT NULL REFERENCES nameserver_group,
-	account_id INT NULL REFERENCES account
+	account_id INT NULL REFERENCES account,
+	status VARCHAR DEFAULT 'active'
 );
 
 CREATE TABLE slavezone (


### PR DESCRIPTION
Adding a status column to the zone table when clean installation is initiated for atomia dns.

Amend PROD-2913

ChangeLog:

* [FIX]