### PR TITLE
Fix: NSEC3 hashes should use encode_base32hex and Feature: Support skipping salt using powerdns_nsec3_salt=-

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.deb
+webapp/package.json.bak

--- a/bind_sync/Makefile.PL
+++ b/bind_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::Bind::Syncer',
-   'VERSION' => '1.1.61',
+   'VERSION' => '1.1.62',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiabindsync' ]
 );

--- a/bind_sync/debian/changelog
+++ b/bind_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-bindsync (1.1.62) hardy; urgency=low
+
+  * Fix NSEC3 ordername with PowerDNS
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Tis, 26 Mar 2024 13:16:25 +0100
+
 atomiadns-bindsync (1.1.61) hardy; urgency=low
 
   * Bump version to 1.1.61

--- a/dyndns/Makefile.PL
+++ b/dyndns/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadyndns',
-   'VERSION' => '1.1.61',
+   'VERSION' => '1.1.62',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadyndns' ]
 );

--- a/dyndns/debian/changelog
+++ b/dyndns/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.62) hardy; urgency=low
+
+  * Fix NSEC3 ordername with PowerDNS
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Tis, 26 Mar 2024 13:16:25 +0100
+
 atomiadns-dyndns (1.1.61) hardy; urgency=low
 
   * Bump version to 1.1.61

--- a/powerdns_sync/Makefile.PL
+++ b/powerdns_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::PowerDNSSyncer',
-   'VERSION' => '1.1.61',
+   'VERSION' => '1.1.62',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiapowerdnssync' ]
 );

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-powerdnssync (1.1.62) hardy; urgency=low
+
+  * Fix NSEC3 ordername with PowerDNS
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Tis, 26 Mar 2024 13:16:25 +0100
+
 atomiadns-powerdnssync (1.1.61) hardy; urgency=low
 
   * Bump version to 1.1.61

--- a/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
+++ b/powerdns_sync/lib/Atomia/DNS/PowerDNSDatabase.pm
@@ -67,21 +67,21 @@ sub dbi {
         }
 }
 
-sub encode_base32 {
-	my $arg = shift;
-	return '' unless defined($arg);    # mimic MIME::Base64
+sub encode_base32hex {
+    my $arg = shift;
+    return '' unless defined($arg);    # mimic MIME::Base64
 
-	$arg = unpack('B*', $arg);
-	$arg =~ s/(.....)/000$1/g;
-	my $l = length($arg);
-	if ($l & 7) {
-		my $e = substr($arg, $l & ~7);
-		$arg = substr($arg, 0, $l & ~7);
-		$arg .= "000$e" . '0' x (5 - length $e);
-	}
-	$arg = pack('B*', $arg);
-	$arg =~ tr|\0-\37|A-Z2-7|;
-	return $arg;
+    $arg = unpack('B*', $arg);
+    $arg =~ s/(.....)/000$1/g;
+    my $l = length($arg);
+    if ($l & 7) {
+        my $e = substr($arg, $l & ~7);
+        $arg = substr($arg, 0, $l & ~7);
+        $arg .= "000$e" . '0' x (5 - length $e);
+    }
+    $arg = pack('B*', $arg);
+    $arg =~ tr|\0-\37|0-9A-V|;
+    return $arg;
 }
 
 sub parse_record {
@@ -109,7 +109,7 @@ sub parse_record {
 			$nsec3 = sha1($nsec3, $self->nsec3_salt);
 		}
 
-		$ordername = lc(encode_base32($nsec3));
+		$ordername = lc(encode_base32hex($nsec3));
 	}
 
 	$ordername = $self->dbi->quote($ordername);

--- a/server/Makefile.PL
+++ b/server/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Server',
-   'VERSION' => '1.1.61',
+   'VERSION' => '1.1.62',
    'AUTHOR' => 'Jimmy Bergman <jimmy@pingdom.com>',
    'DIR' => [],
    'EXE_FILES' => [ 'bin/generate_private_key' ]

--- a/server/SPECS/atomiadns-masterserver.spec
+++ b/server/SPECS/atomiadns-masterserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Complete master SOAP server for Atomia DNS
 Name: atomiadns-masterserver
-Version: 1.1.61
+Version: 1.1.62
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -18,7 +18,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildArch: noarch
 
-Requires: atomiadns-api >= 1.1.61 atomiadns-database >= 1.1.61
+Requires: atomiadns-api >= 1.1.62 atomiadns-database >= 1.1.62
 
 %description
 Complete master SOAP server for Atomia DNS
@@ -37,6 +37,8 @@ Complete master SOAP server for Atomia DNS
 %files
 
 %changelog
+* Tis Mar 26 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.62-1
+- Fix NSEC3 ordername with PowerDNS
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1
 - Bump version to 1.1.61
 * Mon Jun 19 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.60-1

--- a/server/client/Makefile.PL
+++ b/server/client/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadnsclient',
-   'VERSION' => '1.1.61',
+   'VERSION' => '1.1.62',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadnsclient', 'dnssec_zsk_rollover' ]
 );

--- a/server/debian/changelog
+++ b/server/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-masterserver (1.1.62) hardy; urgency=low
+
+  * Fix NSEC3 ordername with PowerDNS
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Tis, 26 Mar 2024 13:16:25 +0100
+
 atomiadns-masterserver (1.1.61) hardy; urgency=low
 
   * Bump version to 1.1.61

--- a/server/debian/control
+++ b/server/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-masterserver
 Architecture: all
-Depends: atomiadns-api (>= 1.1.61), atomiadns-database (>= 1.1.61)
+Depends: atomiadns-api (>= 1.1.62), atomiadns-database (>= 1.1.62)
 Description: Complete master SOAP server for Atomia DNS
 
 Package: atomiadns-api

--- a/syncer/Makefile.PL
+++ b/syncer/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Syncer',
-   'VERSION' => '1.1.61',
+   'VERSION' => '1.1.62',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadnssync' ]
 );

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-nameserver (1.1.62) hardy; urgency=low
+
+  * Fix NSEC3 ordername with PowerDNS
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Tis, 26 Mar 2024 13:16:25 +0100
+
 atomiadns-nameserver (1.1.61) hardy; urgency=low
 
   * Bump version to 1.1.61

--- a/update-version.sh
+++ b/update-version.sh
@@ -73,4 +73,4 @@ find dyndns syncer server zonefileimporter powerdns_sync bind_sync webapp -name 
 done
 
 # Update package.json
-sed -i 's/\("version": "\)[^"]*"/\1'"$version"'"/' */package.json
+sed -i.bak 's/\("version": "\)[^"]*"/\1'"$version"'"/' */package.json

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-webapp (1.1.62) hardy; urgency=low
+
+  * Fix NSEC3 ordername with PowerDNS
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Tis, 26 Mar 2024 13:16:25 +0100
+
 atomiadns-webapp (1.1.61) hardy; urgency=low
 
   * Bump version to 1.1.61

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atomiadns-controlpanel",
-	"version": "1.1.61",
+	"version": "1.1.62",
 	"private": true,
 	"dependencies": {
 		"express":		"= 3.11.0",

--- a/zonefileimporter/Makefile.PL
+++ b/zonefileimporter/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadns_zoneimport',
-   'VERSION' => '1.1.61',
+   'VERSION' => '1.1.62',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadns_zoneimport' ]
 );

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-zoneimport (1.1.62) hardy; urgency=low
+
+  * Fix NSEC3 ordername with PowerDNS
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Tis, 26 Mar 2024 13:16:25 +0100
+
 atomiadns-zoneimport (1.1.61) hardy; urgency=low
 
   * Bump version to 1.1.61


### PR DESCRIPTION
With NSEC3PARAM 1 0 0 - (disregarding the fact that - was disallowed in the powerdns_nsec3_salt validation before this PR) the following was the result:

Before the PR:
https://dnsviz.net/d/wap.pdnstest.roboten-infra.com/ZgK4mg/dnssec/

Notice the bogus response for a record expanded from a wildcard.

After this PR:
https://dnsviz.net/d/wap.pdnstest.roboten-infra.com/ZgK43g/dnssec/

Notice that now the response validates OK for the same record expanded from the wildcard.