### PR TITLE
🔥 Add /usr/bin/atomiadns-sync-powerdns-database PowerDNS database schema update tool on RHEL

### DIFF
--- a/bind_sync/Makefile.PL
+++ b/bind_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::Bind::Syncer',
-   'VERSION' => '1.1.63',
+   'VERSION' => '1.1.64',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiabindsync' ]
 );

--- a/bind_sync/SPECS/atomiadns-bindsync.spec
+++ b/bind_sync/SPECS/atomiadns-bindsync.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS Bindsync application
 Name: atomiadns-bindsync
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -124,6 +124,8 @@ fi
 exit 0
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1

--- a/bind_sync/debian/changelog
+++ b/bind_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-bindsync (1.1.64) hardy; urgency=low
+
+  * Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Fri, 10 May 2024 09:50:19 +0200
+
 atomiadns-bindsync (1.1.63) hardy; urgency=low
 
   * Add atomiapowerdnssync update_dnssec_settings

--- a/dyndns/Makefile.PL
+++ b/dyndns/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadyndns',
-   'VERSION' => '1.1.63',
+   'VERSION' => '1.1.64',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadyndns' ]
 );

--- a/dyndns/SPECS/atomiadns-dyndns.spec
+++ b/dyndns/SPECS/atomiadns-dyndns.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS DDNS server
 Name: atomiadns-dyndns
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -82,6 +82,8 @@ fi
 exit 0
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1

--- a/dyndns/debian/changelog
+++ b/dyndns/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-dyndns (1.1.64) hardy; urgency=low
+
+  * Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Fri, 10 May 2024 09:50:19 +0200
+
 atomiadns-dyndns (1.1.63) hardy; urgency=low
 
   * Add atomiapowerdnssync update_dnssec_settings

--- a/powerdns_sync/Makefile.PL
+++ b/powerdns_sync/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::PowerDNSSyncer',
-   'VERSION' => '1.1.63',
+   'VERSION' => '1.1.64',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiapowerdnssync' ]
 );

--- a/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
+++ b/powerdns_sync/SPECS/atomiadns-powerdnssync.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS PowerDNS Sync application
 Name: atomiadns-powerdnssync
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -40,6 +40,7 @@ Atomia DNS PowerDNS Sync application.
 %{__mkdir} -p %{buildroot}/etc/systemd
 %{__mkdir} -p %{buildroot}/etc/systemd/system
 %{__cp} debian/atomiadns-powerdnssync.atomiadns-powerdnssync.service %{buildroot}/etc/systemd/system/atomiadns-powerdnssync.service
+%{__cp} debian/atomiadns-powerdns-database.postinst %{buildroot}/usr/bin/atomiadns-sync-powerdns-database
 %{__mkdir} -p %{buildroot}/usr/share/atomia/conf
 %{__cp} conf/atomiadns.conf.atomiapowerdnssync %{buildroot}/usr/share/atomia/conf/
 %{__mkdir} -p %{buildroot}/usr/share/atomia/opendnssec_scripts
@@ -85,6 +86,8 @@ fi
 exit 0
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1

--- a/powerdns_sync/debian/atomiadns-powerdns-database.postinst
+++ b/powerdns_sync/debian/atomiadns-powerdns-database.postinst
@@ -22,6 +22,8 @@ if [ -f "/usr/share/atomiadns/powerdns.sql" ]; then
 	schemafile="/usr/share/atomiadns/powerdns.sql"
 elif [ -f "/usr/share/atomiadns/schema/powerdns.sql" ]; then
 	schemafile="/usr/share/atomiadns/schema/powerdns.sql"
+elif [ -f "/usr/share/atomia/powerdns.sql" ]; then
+	schemafile="/usr/share/atomia/powerdns.sql"
 elif [ -f "/usr/local/share/atomiadns/schema/powerdns.sql" ]; then
 	schemafile="/usr/local/share/atomiadns/schema/powerdns.sql"
 else

--- a/powerdns_sync/debian/changelog
+++ b/powerdns_sync/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-powerdnssync (1.1.64) hardy; urgency=low
+
+  * Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Fri, 10 May 2024 09:50:19 +0200
+
 atomiadns-powerdnssync (1.1.63) hardy; urgency=low
 
   * Add atomiapowerdnssync update_dnssec_settings

--- a/server/Makefile.PL
+++ b/server/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Server',
-   'VERSION' => '1.1.63',
+   'VERSION' => '1.1.64',
    'AUTHOR' => 'Jimmy Bergman <jimmy@pingdom.com>',
    'DIR' => [],
    'EXE_FILES' => [ 'bin/generate_private_key' ]

--- a/server/SPECS/atomiadns-api.spec
+++ b/server/SPECS/atomiadns-api.spec
@@ -5,7 +5,7 @@
 
 Summary: SOAP-server for Atomia DNS
 Name: atomiadns-api
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -85,6 +85,8 @@ fi
 exit 0
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1

--- a/server/SPECS/atomiadns-client.spec
+++ b/server/SPECS/atomiadns-client.spec
@@ -5,7 +5,7 @@
 
 Summary: Command line client for Atomia DNS
 Name: atomiadns-client
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: Applications/Internet
@@ -53,6 +53,8 @@ cd ..
 %doc %{_mandir}/man1/dnssec_zsk_rollover.1.gz
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1

--- a/server/SPECS/atomiadns-database.spec
+++ b/server/SPECS/atomiadns-database.spec
@@ -5,7 +5,7 @@
 
 Summary: Database schema for Atomia DNS
 Name: atomiadns-database
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -52,6 +52,8 @@ The Atomia DNS database schema.
 sh /usr/share/atomiadns/atomiadns-database.postinst.sh
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1

--- a/server/SPECS/atomiadns-masterserver.spec
+++ b/server/SPECS/atomiadns-masterserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Complete master SOAP server for Atomia DNS
 Name: atomiadns-masterserver
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -18,7 +18,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildArch: noarch
 
-Requires: atomiadns-api >= 1.1.63 atomiadns-database >= 1.1.63
+Requires: atomiadns-api >= 1.1.64 atomiadns-database >= 1.1.64
 
 %description
 Complete master SOAP server for Atomia DNS
@@ -37,6 +37,8 @@ Complete master SOAP server for Atomia DNS
 %files
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1

--- a/server/client/Makefile.PL
+++ b/server/client/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadnsclient',
-   'VERSION' => '1.1.63',
+   'VERSION' => '1.1.64',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadnsclient', 'dnssec_zsk_rollover' ]
 );

--- a/server/debian/changelog
+++ b/server/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-masterserver (1.1.64) hardy; urgency=low
+
+  * Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Fri, 10 May 2024 09:50:19 +0200
+
 atomiadns-masterserver (1.1.63) hardy; urgency=low
 
   * Add atomiapowerdnssync update_dnssec_settings

--- a/server/debian/control
+++ b/server/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.6.1
 
 Package: atomiadns-masterserver
 Architecture: all
-Depends: atomiadns-api (>= 1.1.63), atomiadns-database (>= 1.1.63)
+Depends: atomiadns-api (>= 1.1.64), atomiadns-database (>= 1.1.64)
 Description: Complete master SOAP server for Atomia DNS
 
 Package: atomiadns-api

--- a/syncer/Makefile.PL
+++ b/syncer/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'Atomia::DNS::Syncer',
-   'VERSION' => '1.1.63',
+   'VERSION' => '1.1.64',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'bin/atomiadnssync' ]
 );

--- a/syncer/SPECS/atomiadns-nameserver.spec
+++ b/syncer/SPECS/atomiadns-nameserver.spec
@@ -5,7 +5,7 @@
 
 Summary: Atomia DNS Sync application
 Name: atomiadns-nameserver
-Version: 1.1.63
+Version: 1.1.64
 Release: 1%{?dist}
 License: Commercial
 Group: System Environment/Daemons
@@ -108,6 +108,8 @@ fi
 exit 0
 
 %changelog
+* Fri May 10 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.64-1
+- Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
 * Wed Mar 27 2024 Jimmy Bergman <jimmy@sigint.se> - 1.1.63-1
 - Add atomiapowerdnssync update_dnssec_settings
 * Thu Oct 12 2023 Nemanja Zivkovic <nemanja.zivkovic@atomia.com> - 1.1.61-1

--- a/syncer/debian/changelog
+++ b/syncer/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-nameserver (1.1.64) hardy; urgency=low
+
+  * Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Fri, 10 May 2024 09:50:19 +0200
+
 atomiadns-nameserver (1.1.63) hardy; urgency=low
 
   * Add atomiapowerdnssync update_dnssec_settings

--- a/webapp/debian/changelog
+++ b/webapp/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-webapp (1.1.64) hardy; urgency=low
+
+  * Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Fri, 10 May 2024 09:50:19 +0200
+
 atomiadns-webapp (1.1.63) hardy; urgency=low
 
   * Add atomiapowerdnssync update_dnssec_settings

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atomiadns-controlpanel",
-	"version": "1.1.63",
+	"version": "1.1.64",
 	"private": true,
 	"dependencies": {
 		"express":		"= 3.11.0",

--- a/zonefileimporter/Makefile.PL
+++ b/zonefileimporter/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
    'NAME' => 'atomiadns_zoneimport',
-   'VERSION' => '1.1.63',
+   'VERSION' => '1.1.64',
    'AUTHOR' => 'Jimmy Bergman <jimmy@atomia.com>',
    'EXE_FILES' => [ 'atomiadns_zoneimport' ]
 );

--- a/zonefileimporter/debian/changelog
+++ b/zonefileimporter/debian/changelog
@@ -1,3 +1,9 @@
+atomiadns-zoneimport (1.1.64) hardy; urgency=low
+
+  * Add /usr/bin/atomiadns-sync-powerdns-database on RHEL
+
+ -- Jimmy Bergman <jimmy@sigint.se>  Fri, 10 May 2024 09:50:19 +0200
+
 atomiadns-zoneimport (1.1.63) hardy; urgency=low
 
   * Add atomiapowerdnssync update_dnssec_settings


### PR DESCRIPTION
To check if you need to update the PowerDNS schema:

Check the powerdns_schemaversion table and if it is less than in the value at the top of /usr/share/atomia/powerdns.sql then you need to update.

To update call:
/usr/bin/atomiadns-sync-powerdns-database